### PR TITLE
Fix for building on GHC-7.4.1

### DIFF
--- a/Data/Semigroupoid/Static.hs
+++ b/Data/Semigroupoid/Static.hs
@@ -11,7 +11,6 @@ import Control.Monad.Instances
 import Control.Monad (ap)
 import Data.Functor.Apply
 import Data.Functor.Plus
-import Data.Monoid
 import Data.Semigroup
 import Data.Semigroupoid
 import Prelude hiding ((.), id)


### PR DESCRIPTION
Hi Edward,

`Data.Monoid` from `base-4.5` exports the (`<>`) function. This conflicts with the one from `Data.Semigroup`. The import of `Data.Monoid` does not appear to be necessary so I just removed it.

Cheers,

Bas
