### PR TITLE
Fixed docs for Data.Functor.Extend

### DIFF
--- a/Data/Functor/Extend.hs
+++ b/Data/Functor/Extend.hs
@@ -12,7 +12,7 @@
 module Data.Functor.Extend
   ( -- * Extendable Functors
    
-    -- $documentation
+    -- $definition
     Extend(..)
   ) where
 
@@ -95,30 +95,27 @@ instance Extend NonEmpty where
       []     -> []
       (a:as) -> toList (extended f (a :| as))
 
-{- $definition
-
-There are two ways to define an 'Extend' instance:
-
-I. Provide definitions for 'extend'
-satisfying this law:
-
-> extended f . extended g = extended (f . extended g)
-
-II. Alternately, you may choose to provide definitions for 'duplicate'
-satisfying this law:
-
-> duplicated . duplicated = fmap duplicated . duplicated
-
-These are both equivalent to the statement that (->-) is associative
-
-> (f ->- g) ->- h = f ->- (g ->- h)
-
-You may of course, choose to define both 'duplicate' /and/ 'extend'.
-In that case you must also satisfy these laws:
-
-> extended f = fmap f . duplicated
-> duplicated = extended id
-
-These are the default definitions of 'extended' and 'duplicated'.
-
--}
+-- $definition
+--There are two ways to define an 'Extend' instance:
+--
+--I. Provide definitions for 'extend'
+--satisfying this law:
+--
+--> extended f . extended g = extended (f . extended g)
+--
+--II. Alternately, you may choose to provide definitions for 'duplicate'
+--satisfying this law:
+--
+--> duplicated . duplicated = fmap duplicated . duplicated
+--
+--These are both equivalent to the statement that (->-) is associative
+--
+--> (f ->- g) ->- h = f ->- (g ->- h)
+--
+--You may of course, choose to define both 'duplicate' /and/ 'extend'.
+--In that case you must also satisfy these laws:
+--
+--> extended f = fmap f . duplicated
+--> duplicated = extended id
+--
+--These are the default definitions of 'extended' and 'duplicated'.


### PR DESCRIPTION
Replaced old names ("extend" for "extended" etc), and fixed the missing bit of documentation and incorrect header.
