### PR TITLE
Depend on base-compat for Foldable/Traversable orphan instances

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+4.4
+---
+* Added dependency on `base-compat`, which contains orphan `Foldable` and `Traversable` instances for `Either`, `Const`, and `(,)`.
+* The `Data.Traversable.Instances` module now reexports the orphan instances from `base-compat`.
+
 4.3.1
 -----
 * Added `asum1` to `Data.Semigroup.Foldable`.

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -105,6 +105,7 @@ flag comonad
 library
   build-depends:
     base                >= 4       && < 5,
+    base-compat         >= 0.4     && < 1,
     semigroups          >= 0.8.3.1 && < 1,
     transformers        >= 0.2     && < 0.6,
     transformers-compat >= 0.3     && < 0.5

--- a/src/Data/Traversable/Instances.hs
+++ b/src/Data/Traversable/Instances.hs
@@ -2,26 +2,18 @@
 #ifndef MIN_VERSION_transformers
 #define MIN_VERSION_transformers(x,y,z) 1
 #endif
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
 -- | Placeholders for missing instances of Traversable, until base catches up and adds them
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Traversable.Instances where
 
 #if !(MIN_VERSION_transformers(0,3,0))
 import Control.Monad.Trans.Identity
-#endif
-
-#if !((MIN_VERSION_transformers(0,3,0)) && (MIN_VERSION_base(4,7,0)))
 import Data.Foldable
 import Data.Traversable
 #endif
 
-#if !(MIN_VERSION_base(4,7,0))
-import Control.Applicative
-import Data.Monoid
-#endif
+-- Imports orphan Foldable/Traversable instances for (,), Either, and Const
+import Data.Traversable.Compat ()
 
 #if !(MIN_VERSION_transformers(0,3,0))
 instance Foldable m => Foldable (IdentityT m) where
@@ -29,28 +21,4 @@ instance Foldable m => Foldable (IdentityT m) where
 
 instance Traversable m => Traversable (IdentityT m) where
   traverse f = fmap IdentityT . traverse f . runIdentityT
-#endif
-
---------------------------------------
-
-#if !(MIN_VERSION_base(4,7,0))
-instance Foldable ((,) b) where
-  foldMap f (_, a) = f a
-
-instance Traversable ((,) b) where
-  traverse f (b, a) = (,) b <$> f a
-
-instance Foldable (Either a) where
-  foldMap _ (Left _) = mempty
-  foldMap f (Right a) = f a
-
-instance Traversable (Either a) where
-  traverse _ (Left b) = pure (Left b)
-  traverse f (Right a) = Right <$> f a
-
-instance Foldable (Const m) where
-  foldMap _ _ = mempty
-
-instance Traversable (Const m) where
-  traverse _ (Const m) = pure $ Const m
 #endif


### PR DESCRIPTION
At the moment, both the `base-compat` and `semigroupoids` libraries expose orphan `Foldable` and `Traversable` instances for `Either`, `Const`, and `(,)`, which means they can't be used together. Since `base-compat` was created for the purpose of backporting new features of `base` (including orphan instances), I feel like it makes more sense for them to be defined in `base-compat`. This commit adds a dependency on `base-compat` and reexports the orphan instances from `Data.Traversable.Instances`.


See also [this pull request](https://github.com/ekmett/lens/pull/539) for `lens`.