### PR TITLE
Use base-orphans to import Foldable/Traversable orphan instances

### DIFF
--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -105,6 +105,7 @@ flag comonad
 library
   build-depends:
     base                >= 4       && < 5,
+    base-orphans        >= 0.3     && < 1,
     semigroups          >= 0.8.3.1 && < 1,
     transformers        >= 0.2     && < 0.6,
     transformers-compat >= 0.3     && < 0.5

--- a/src/Data/Traversable/Instances.hs
+++ b/src/Data/Traversable/Instances.hs
@@ -9,48 +9,16 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Traversable.Instances where
 
+import Data.Orphans ()
+
 #if !(MIN_VERSION_transformers(0,3,0))
 import Control.Monad.Trans.Identity
-#endif
-
-#if !((MIN_VERSION_transformers(0,3,0)) && (MIN_VERSION_base(4,7,0)))
 import Data.Foldable
 import Data.Traversable
-#endif
 
-#if !(MIN_VERSION_base(4,7,0))
-import Control.Applicative
-import Data.Monoid
-#endif
-
-#if !(MIN_VERSION_transformers(0,3,0))
 instance Foldable m => Foldable (IdentityT m) where
   foldMap f = foldMap f . runIdentityT
 
 instance Traversable m => Traversable (IdentityT m) where
   traverse f = fmap IdentityT . traverse f . runIdentityT
-#endif
-
---------------------------------------
-
-#if !(MIN_VERSION_base(4,7,0))
-instance Foldable ((,) b) where
-  foldMap f (_, a) = f a
-
-instance Traversable ((,) b) where
-  traverse f (b, a) = (,) b <$> f a
-
-instance Foldable (Either a) where
-  foldMap _ (Left _) = mempty
-  foldMap f (Right a) = f a
-
-instance Traversable (Either a) where
-  traverse _ (Left b) = pure (Left b)
-  traverse f (Right a) = Right <$> f a
-
-instance Foldable (Const m) where
-  foldMap _ _ = mempty
-
-instance Traversable (Const m) where
-  traverse _ (Const m) = pure $ Const m
 #endif


### PR DESCRIPTION
My second attempt (after #27) at consolidating some surprisingly common orphan instances that appear in `semigroupoids` (as well as [`functor-combo`](https://github.com/conal/functor-combo/blob/885752a0b58a2e9e606401da9ed8a4f0fe823680/src/FunctorCombo/Functor.hs#L115-118), [`infernu`](https://github.com/sinelaw/infernu/blob/405685e3cc92ddc722d4bb0ea549b21553cce1f2/src/Infernu/Prelude.hs#L40-43), [`witherable`](https://github.com/fumieval/witherable/blob/ea39bbf04ce9ef2e12711601c88605276f2af68d/src/Data/Witherable.hs#L125-139), ...) by means of a common package for these orphans.

To impose less of a burden (as opposed to [`base-compat`](http://hackage.haskell.org/package/base-compat)) on introducing a new dependency for this package, `base-orphans`:

* Defines orphan instances and nothing else, making it near-instant to install
* Only depends on `base` and `ghc-prim`
* Is `Trustworthy`, so it shouldn't break any `Safe` modules in `semigroupoids`