### PR TITLE
Remove Coproduct instances, add Sum instance

### DIFF
--- a/src/Data/Functor/Extend.hs
+++ b/src/Data/Functor/Extend.hs
@@ -24,7 +24,8 @@ import Prelude hiding (id, (.))
 import Control.Category
 import Control.Monad.Trans.Identity
 import Data.Functor.Identity
-import Data.Semigroup
+import Data.Functor.Sum (Sum(..))
+import Data.Semigroup (Semigroup(..))
 import Data.List (tails)
 import Data.List.NonEmpty (NonEmpty(..), toList)
 
@@ -36,7 +37,6 @@ import Data.Tree
 
 
 #ifdef MIN_VERSION_comonad
-import Data.Functor.Coproduct
 import Control.Comonad.Trans.Env
 import Control.Comonad.Trans.Store
 import Control.Comonad.Trans.Traced
@@ -95,10 +95,12 @@ instance Extend Tree where
 #endif
 
 #ifdef MIN_VERSION_comonad
+{-
 instance (Extend f, Extend g) => Extend (Coproduct f g) where
   extended f = Coproduct . coproduct
     (Left . extended (f . Coproduct . Left))
     (Right . extended (f . Coproduct . Right))
+-}
 
 instance Extend w => Extend (EnvT e w) where
   duplicated (EnvT e wa) = EnvT e (extended (EnvT e) wa)
@@ -132,6 +134,10 @@ instance Extend NonEmpty where
   extended f w@ ~(_ :| aas) = f w :| case aas of
       []     -> []
       (a:as) -> toList (extended f (a :| as))
+
+instance (Extend f, Extend g) => Extend (Sum f g) where
+  extended f (InL l) = InL (extended (f . InL) l)
+  extended f (InR r) = InR (extended (f . InR) r)
 
 -- $definition
 -- There are two ways to define an 'Extend' instance:

--- a/src/Data/Semigroup/Foldable/Class.hs
+++ b/src/Data/Semigroup/Foldable/Class.hs
@@ -35,10 +35,6 @@ import Data.Bifunctor.Wrapped
 import Data.Foldable
 import Data.Functor.Compose
 
-#ifdef MIN_VERSION_comonad
-import Data.Functor.Coproduct
-#endif
-
 import Data.Functor.Identity
 import Data.Functor.Product as Functor
 import Data.Functor.Reverse
@@ -167,11 +163,6 @@ instance Foldable1 f => Foldable1 (Reverse f) where
 instance (Foldable1 f, Foldable1 g) => Foldable1 (Sum f g) where
   foldMap1 f (InL x) = foldMap1 f x
   foldMap1 f (InR y) = foldMap1 f y
-
-#ifdef MIN_VERSION_comonad
-instance (Foldable1 f, Foldable1 g) => Foldable1 (Coproduct f g) where
-  foldMap1 f = coproduct (foldMap1 f) (foldMap1 f)
-#endif
 
 instance Foldable1 NonEmpty where
   foldMap1 f (a :| []) = f a

--- a/src/Data/Semigroup/Traversable/Class.hs
+++ b/src/Data/Semigroup/Traversable/Class.hs
@@ -31,10 +31,6 @@ import Data.Bifunctor.Wrapped
 import Data.Functor.Apply
 import Data.Functor.Compose
 
-#ifdef MIN_VERSION_comonad
-import Data.Functor.Coproduct as Functor
-#endif
-
 import Data.Functor.Identity
 import Data.Functor.Product as Functor
 import Data.Functor.Reverse
@@ -170,13 +166,6 @@ instance Traversable1 f => Traversable1 (Reverse f) where
 instance (Traversable1 f, Traversable1 g) => Traversable1 (Functor.Sum f g) where
   traverse1 f (Functor.InL x) = Functor.InL <$> traverse1 f x
   traverse1 f (Functor.InR y) = Functor.InR <$> traverse1 f y
-
-#ifdef MIN_VERSION_comonad
-instance (Traversable1 f, Traversable1 g) => Traversable1 (Coproduct f g) where
-  traverse1 f = coproduct
-    (fmap (Coproduct . Left) . traverse1 f)
-    (fmap (Coproduct . Right) . traverse1 f)
-#endif
 
 #ifdef MIN_VERSION_containers
 instance Traversable1 Tree where


### PR DESCRIPTION
The HEAD version of `comonad` has removed `Coproduct` in favor of `Sum`, so I did the same with `semigroupoids`. I also added an `Extend` instance for `Sum` to compensate for the removed `Extend` instance for `Coproduct`.

I had to fix this in the process of dealing with [this issue](https://github.com/ekmett/free/pull/123).