### PR TITLE
Consolidate transformers-related orphans with transformers-compat-0.5

### DIFF
--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -111,7 +111,7 @@ flag tagged
     Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
   default: True
   manual: True
-  
+
 library
   build-depends:
     base                >= 4       && < 5,
@@ -119,7 +119,7 @@ library
     bifunctors          >= 5       && < 6,
     semigroups          >= 0.8.3.1 && < 1,
     transformers        >= 0.2     && < 0.6,
-    transformers-compat >= 0.3     && < 0.6
+    transformers-compat >= 0.5     && < 0.6
 
   if flag(containers)
     build-depends: containers >= 0.3 && < 0.6
@@ -131,7 +131,7 @@ library
     build-depends: distributive >= 0.2.2 && < 1
 
   if flag(comonad)
-    build-depends: comonad >= 4.2.6 && < 5
+    build-depends: comonad >= 4.2.6 && < 6
 
   if flag(tagged)
     build-depends: tagged >= 0.7.3 && < 1

--- a/src/Data/Traversable/Instances.hs
+++ b/src/Data/Traversable/Instances.hs
@@ -1,10 +1,3 @@
-{-# LANGUAGE CPP #-}
-#ifndef MIN_VERSION_transformers
-#define MIN_VERSION_transformers(x,y,z) 1
-#endif
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -14,24 +7,9 @@
 -- Stability   :  provisional
 -- Portability :  polykinds
 --
--- Placeholders for missing instances of 'Traversable', and 'Foldable' until
--- base catches up and adds them. Many of these are re-exports from the
--- `base-orphans` package.
+-- Re-exports from the `base-orphans` and `transformers-compat` packages.
 ----------------------------------------------------------------------------
-
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Traversable.Instances where
 
+import Control.Monad.Trans.Instances ()
 import Data.Orphans ()
-
-#if !(MIN_VERSION_transformers(0,3,0))
-import Control.Monad.Trans.Identity
-import Data.Foldable
-import Data.Traversable
-
-instance Foldable m => Foldable (IdentityT m) where
-  foldMap f = foldMap f . runIdentityT
-
-instance Traversable m => Traversable (IdentityT m) where
-  traverse f = fmap IdentityT . traverse f . runIdentityT
-#endif


### PR DESCRIPTION
Also bumps the upper version bounds of `comonad`, which happened on Hackage but not here.