### PR TITLE
Adding toNonEmpty, foldrM1, & foldlM1 to Foldable1 module.

### DIFF
--- a/src/Data/Semigroup/Foldable.hs
+++ b/src/Data/Semigroup/Foldable.hs
@@ -17,11 +17,14 @@ module Data.Semigroup.Foldable
   , sequenceA1_
   , foldMapDefault1
   , asum1
+  , foldrM1
+  , foldlM1
   ) where
 
 import Data.Foldable
 import Data.Functor.Alt (Alt(..))
 import Data.Functor.Apply
+import Data.List.NonEmpty (NonEmpty(..))
 import Data.Traversable.Instances ()
 import Data.Semigroup hiding (Product, Sum)
 import Data.Semigroup.Foldable.Class
@@ -99,3 +102,30 @@ instance Alt f => Semigroup (Alt_ f a) where
 asum1 :: (Foldable1 t, Alt m) => t (m a) -> m a
 asum1 = getAlt_ . foldMap1 Alt_
 {-# INLINE asum1 #-}
+
+-- | Monadic fold over the elements of a non-empty structure,
+-- associating to the right, i.e. from right to left.
+--
+-- > let g = (=<<) . f
+-- > in foldrM1 f (x1 :| [x2, ..., xn]) == x1 `g` (x2 `g` ... (xn-1 `f` xn)...)
+--
+foldrM1 :: (Foldable1 t, Monad m) => (a -> a -> m a) -> t a -> m a
+foldrM1 f = go . toNonEmpty
+  where
+    g = (=<<) . f
+    
+    go (e:|es) =
+      case es of
+        []   -> pure e
+        x:xs -> e `g` (go (x:|xs))
+
+-- | Monadic fold over the elements of a non-empty structure,
+-- associating to the left, i.e. from left to right.
+--
+-- > let g = flip $ (=<<) . f
+-- > in foldlM1 f (x1 :| [x2, ..., xn]) == (...((x1 `f` x2) `g` x2) `g`...) `g` xn
+--
+foldlM1 :: (Foldable1 t, Monad m) => (a -> a -> m a) -> t a -> m a
+foldlM1 f t = foldlM f x xs
+  where
+    x:|xs = toNonEmpty t

--- a/src/Data/Semigroup/Foldable.hs
+++ b/src/Data/Semigroup/Foldable.hs
@@ -116,7 +116,7 @@ foldrM1 f = go . toNonEmpty
     
     go (e:|es) =
       case es of
-        []   -> pure e
+        []   -> return e
         x:xs -> e `g` (go (x:|xs))
 
 -- | Monadic fold over the elements of a non-empty structure,

--- a/src/Data/Semigroup/Foldable/Class.hs
+++ b/src/Data/Semigroup/Foldable/Class.hs
@@ -64,9 +64,11 @@ import Prelude hiding (foldr)
 class Foldable t => Foldable1 t where
   fold1 :: Semigroup m => t m -> m
   foldMap1 :: Semigroup m => (a -> m) -> t a -> m
+  toNonEmpty :: t a -> NonEmpty a
 
   foldMap1 f = maybe (error "foldMap1") id . getOption . foldMap (Option . Just . f)
   fold1 = foldMap1 id
+  toNonEmpty = foldMap1 (:|[])
 
 instance Foldable1 f => Foldable1 (Rec1 f) where
   foldMap1 f (Rec1 as) = foldMap1 f as
@@ -207,6 +209,7 @@ instance (Foldable1 f, Foldable1 g) => Foldable1 (Sum f g) where
 instance Foldable1 NonEmpty where
   foldMap1 f (a :| []) = f a
   foldMap1 f (a :| b : bs) = f a <> foldMap1 f (b :| bs)
+  toNonEmpty = id
 
 instance Foldable1 ((,) a) where
   foldMap1 f (_, x) = f x


### PR DESCRIPTION
Added the function `toNonEmpty` to the `Foldbable1` type-class. 

This allows a `Foldable1` type to produce a non-empty list of it's elements, analogous to a `Foldable` type's ability to produce a (possibly empty) list it's elements.
However `toNonEmpty` preserves the additional constraint that the non-empty structure of `Foldable1` produces a non-empty list.

While a `Foldable` structure can have "list-like" operations performed on it's elements my calling `toList` on the structure and then using functions from `Prelude` or `Data.List`, the addition of `toNonEmpty` allows for "list-like" operations from `Data.List.NonEmpty` to be performed on the elements of a `Foldable1` _in a type-safe manner_ after calling `toNonEmpty` on the structure.

I also implemented `foldrM1` and `foldlM1` (biasing right and left respectively) which fold a binary operation that produces a monadic result over non-empty structure.