### PR TITLE
Add Apply, Bind, Foldable1, Traversable1 instances for Complex

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+next
+----
+* Add `Apply`, `Bind`, `Foldable1`, and `Traversable1` instances for `Complex`
+
 5.2
 ---
 * Revamp `Setup.hs` to use `cabal-doctest`. This makes it build

--- a/src/Data/Functor/Bind/Class.hs
+++ b/src/Data/Functor/Bind/Class.hs
@@ -82,6 +82,10 @@ import Data.List.NonEmpty
 import Data.Orphans ()
 import Prelude hiding (id, (.))
 
+#if MIN_VERSION_base(4,4,0)
+import Data.Complex
+#endif
+
 #ifdef MIN_VERSION_containers
 import qualified Data.IntMap as IntMap
 import Data.IntMap (IntMap)
@@ -254,6 +258,11 @@ instance Arrow a => Apply (WrappedArrow a b) where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
+
+#if MIN_VERSION_base(4,4,0)
+instance Apply Complex where
+  (a :+ b) <.> (c :+ d) = a c :+ b d
+#endif
 
 #ifdef MIN_VERSION_containers
 -- | A Map is not 'Applicative', but it is an instance of 'Apply'
@@ -547,6 +556,14 @@ instance Bind (ContT r m) where
 instance ArrowApply a => Bind (WrappedArrow a b) where
   (>>-) = (>>=)
 -}
+
+#if MIN_VERSION_base(4,4,0)
+instance Bind Complex where
+  (a :+ b) >>- f = a' :+ b' where
+    a' :+ _  = f a
+    _  :+ b' = f b
+  {-# INLINE (>>-) #-}
+#endif
 
 #ifdef MIN_VERSION_containers
 -- | A 'Map' is not a 'Monad', but it is an instance of 'Bind'

--- a/src/Data/Semigroup/Foldable/Class.hs
+++ b/src/Data/Semigroup/Foldable/Class.hs
@@ -41,6 +41,10 @@ import Data.Functor.Reverse
 import Data.Functor.Sum
 import Data.List.NonEmpty (NonEmpty(..))
 
+#if MIN_VERSION_base(4,4,0)
+import Data.Complex
+#endif
+
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
 #endif
@@ -166,6 +170,12 @@ instance (Foldable1 f, Bifoldable1 p) => Bifoldable1 (Tannen f p) where
 instance Bifoldable1 p => Bifoldable1 (WrappedBifunctor p) where
   bifoldMap1 f g = bifoldMap1 f g . unwrapBifunctor
   {-# INLINE bifoldMap1 #-}
+
+#if MIN_VERSION_base(4,4,0)
+instance Foldable1 Complex where
+  foldMap1 f (a :+ b) = f a <> f b
+  {-# INLINE foldMap1 #-}
+#endif
 
 #ifdef MIN_VERSION_containers
 instance Foldable1 Tree where

--- a/src/Data/Semigroup/Traversable/Class.hs
+++ b/src/Data/Semigroup/Traversable/Class.hs
@@ -47,6 +47,10 @@ import Data.Traversable
 #endif
 import Data.Traversable.Instances ()
 
+#if MIN_VERSION_base(4,4,0)
+import Data.Complex
+#endif
+
 #ifdef MIN_VERSION_containers
 import Data.Tree
 #endif
@@ -199,6 +203,12 @@ instance Traversable1 f => Traversable1 (Reverse f) where
 instance (Traversable1 f, Traversable1 g) => Traversable1 (Functor.Sum f g) where
   traverse1 f (Functor.InL x) = Functor.InL <$> traverse1 f x
   traverse1 f (Functor.InR y) = Functor.InR <$> traverse1 f y
+
+#if MIN_VERSION_base(4,4,0)
+instance Traversable1 Complex where
+  traverse1 f (a :+ b) = (:+) <$> f a <.> f b
+  {-# INLINE traverse1 #-}
+#endif
 
 #ifdef MIN_VERSION_tagged
 instance Traversable1 (Tagged a) where


### PR DESCRIPTION
This adopts some [orphan instances](http://hackage.haskell.org/package/linear-1.20.6/docs/src/Linear-Instances.html) from `linear`.