### PR TITLE
Add Apply, Bind instances for HashMap

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 -----
 * Add `Apply`, `Bind`, `Foldable1`, and `Traversable1` instances for `Complex`
 * Add `Semigroupoid` instance for `Tagged`
+* Add `Apply` and `Bind` instances for `HashMap` from the `unordered-containers` package
+  (on which `semigroupoids` now depends)
 
 5.2
 ---

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -118,6 +118,14 @@ flag tagged
   default: True
   manual: True
 
+flag unordered-containers
+  description:
+    You can disable the use of the `unordered-containers` package (and also its dependency `hashable`) using `-f-unordered-containers`.
+    .
+    Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+  default: True
+  manual: True
+
 library
   build-depends:
     base                >= 4.3     && < 5,
@@ -147,6 +155,10 @@ library
 
   if flag(tagged)
     build-depends: tagged >= 0.7.3 && < 1
+
+  if flag(unordered-containers)
+    build-depends: hashable >= 1.1  && < 1.3,
+                   unordered-containers >= 0.2  && < 0.3
 
   hs-source-dirs: src
 


### PR DESCRIPTION
This migrates two more orphan instances from `linear`. Doing this will require incurring an additional `unordered-containers` dependency, but I think this is reasonable.