### PR TITLE
Fix the build post-Semigroup–Monoid Proposal

### DIFF
--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -50,8 +50,8 @@ import Data.Functor.Bind
 import Data.Functor.Compose
 import Data.Functor.Product
 import Data.Functor.Reverse
-import Data.Semigroup hiding (Product)
 import Data.List.NonEmpty (NonEmpty(..))
+import Data.Semigroup (Option(..), Semigroup(..))
 import Prelude (($),Either(..),Maybe(..),const,IO,Ord,(++),(.),either,seq,undefined)
 import Unsafe.Coerce
 
@@ -61,6 +61,11 @@ import Data.IntMap (IntMap)
 import Data.Sequence (Seq)
 import qualified Data.Map as Map
 import Data.Map (Map)
+# if MIN_VERSION_base(4,8,0)
+import Prelude (mappend)
+# else
+import Data.Monoid (mappend)
+# endif
 #endif
 
 #if defined(MIN_VERSION_tagged) || (MIN_VERSION_base(4,7,0))
@@ -72,6 +77,7 @@ import Generics.Deriving.Base
 #else
 import GHC.Generics
 #endif
+
 
 infixl 3 <!>
 

--- a/src/Data/Functor/Bind/Trans.hs
+++ b/src/Data/Functor/Bind/Trans.hs
@@ -31,7 +31,9 @@ import qualified Control.Monad.Trans.State.Strict as Strict
 import qualified Control.Monad.Trans.Writer.Strict as Strict
 import Data.Functor.Bind
 import Data.Orphans ()
+#if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup hiding (Product)
+#endif
 import Prelude hiding (id, (.))
 
 -- | A subset of monad transformers can transform any 'Bind' as well.

--- a/src/Data/Semigroup/Bitraversable.hs
+++ b/src/Data/Semigroup/Bitraversable.hs
@@ -15,7 +15,9 @@ module Data.Semigroup.Bitraversable
   ) where
 
 import Control.Applicative
+#if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup
+#endif
 import Data.Semigroup.Traversable.Class
 
 bifoldMap1Default :: (Bitraversable1 t, Semigroup m) => (a -> m) -> (b -> m) -> t a b -> m

--- a/src/Data/Semigroup/Traversable.hs
+++ b/src/Data/Semigroup/Traversable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -14,7 +15,9 @@ module Data.Semigroup.Traversable
   ) where
 
 import Control.Applicative
+#if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup
+#endif
 import Data.Semigroup.Traversable.Class
 
 foldMap1Default :: (Traversable1 f, Semigroup m) => (a -> m) -> f a -> m


### PR DESCRIPTION
`Data.Semigroup` no longer exports `Monoid(..)` in GHC HEAD, so some minor import surgery is required to fix the `semigroupoids` build.