### PR TITLE
Apply and Bind instances for Q (from template-haskell).

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -6,6 +6,7 @@ next
   is now a class method of `Applicative`). `liftF2` and `(<.>)` have default
   definitions in terms of the other.
 * Allow building with GHC 8.4
+* `Apply` and `Bind` instances for `Q`, from the `template-haskell` package.
 
 5.2.1
 -----

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -132,6 +132,7 @@ library
     base-orphans        >= 0.5.4   && < 1,
     bifunctors          >= 5       && < 6,
     semigroups          >= 0.8.3.1 && < 1,
+    template-haskell,
     transformers        >= 0.2     && < 0.6,
     transformers-compat >= 0.5     && < 0.6
 

--- a/src/Data/Functor/Bind/Class.hs
+++ b/src/Data/Functor/Bind/Class.hs
@@ -280,8 +280,10 @@ instance Apply Complex where
   (a :+ b) <.> (c :+ d) = a c :+ b d
 #endif
 
+-- Applicative Q was only added in template-haskell 2.7 (GHC 7.4), so
+-- define in terms of Monad instead.
 instance Apply Q where
-  (<.>) = (<*>)
+  (<.>) = ap
 
 #ifdef MIN_VERSION_containers
 -- | A Map is not 'Applicative', but it is an instance of 'Apply'

--- a/src/Data/Functor/Bind/Class.hs
+++ b/src/Data/Functor/Bind/Class.hs
@@ -80,6 +80,7 @@ import Data.Functor.Reverse
 import Data.Functor.Extend
 import Data.List.NonEmpty
 import Data.Orphans ()
+import Language.Haskell.TH (Q)
 import Prelude hiding (id, (.))
 
 #if MIN_VERSION_base(4,4,0)
@@ -278,6 +279,9 @@ instance Arrow a => Apply (WrappedArrow a b) where
 instance Apply Complex where
   (a :+ b) <.> (c :+ d) = a c :+ b d
 #endif
+
+instance Apply Q where
+  (<.>) = (<*>)
 
 #ifdef MIN_VERSION_containers
 -- | A Map is not 'Applicative', but it is an instance of 'Apply'
@@ -505,6 +509,9 @@ instance Bind Option where
   (>>-) = (>>=)
 
 instance Bind Identity where
+  (>>-) = (>>=)
+
+instance Bind Q where
   (>>-) = (>>=)
 
 instance Bind m => Bind (IdentityT m) where


### PR DESCRIPTION
template-haskell is already a transitive dependency (via bifunctors).

I left template-haskell boundsless in build-depends because it's tied to the GHC being used, and defining these instances doesn't actually use any of the things that are ever going to change.