### PR TITLE
Alt and Plus instances for Data.(Semigroup|Monoid).(First|Last)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -7,6 +7,8 @@ next
   definitions in terms of the other.
 * Allow building with GHC 8.4
 * `Apply` and `Bind` instances for `Q`, from the `template-haskell` package.
+* `Alt` instances for `First` and `Last` from `Data.Semigroup`, and
+  `Alt` and `Plus` instances for `First` and `Last` from `Data.Monoid`.
 
 5.2.1
 -----

--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -52,7 +52,9 @@ import Data.Functor.Compose
 import Data.Functor.Product
 import Data.Functor.Reverse
 import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.Monoid as Monoid
 import Data.Semigroup (Option(..), Semigroup(..))
+import qualified Data.Semigroup as Semigroup
 import Prelude (($),Either(..),Maybe(..),const,IO,Ord,(++),(.),either,seq,undefined)
 import Unsafe.Coerce
 
@@ -268,3 +270,15 @@ instance (Alt f, Alt g) => Alt (Product f g) where
 
 instance Alt f => Alt (Reverse f) where
   Reverse a <!> Reverse b = Reverse (a <!> b)
+
+instance Alt Semigroup.First where
+  (<!>) = (<>)
+
+instance Alt Semigroup.Last where
+  (<!>) = (<>)
+
+instance Alt Monoid.First where
+  (<!>) = mappend
+
+instance Alt Monoid.Last where
+  (<!>) = mappend

--- a/src/Data/Functor/Plus.hs
+++ b/src/Data/Functor/Plus.hs
@@ -44,6 +44,7 @@ import Data.Functor.Bind
 import Data.Functor.Compose
 import Data.Functor.Product
 import Data.Functor.Reverse
+import qualified Data.Monoid as Monoid
 import Data.Semigroup hiding (Product)
 import Prelude hiding (id, (.))
 
@@ -172,3 +173,9 @@ instance (Plus f, Plus g) => Plus (Product f g) where
 
 instance Plus f => Plus (Reverse f) where
   zero = Reverse zero
+
+instance Plus Monoid.First where
+  zero = Monoid.First Nothing
+
+instance Plus Monoid.Last where
+  zero = Monoid.Last Nothing


### PR DESCRIPTION
No instances for `Min` and `Max` because of the `Ord` constraint.