### PR TITLE
Conditionalise the semigroups dep

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,7 @@
 Next
 ----
-* Bump the lower bound on `semigroups` to 0.16.2.
+* Bump the lower bound on `semigroups` to 0.16.2, and avoid incurring
+  the dependency entirely on recent GHCs.
 
 5.3.1 [2018.07.02]
 ------------------

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+Next
+----
+* Bump the lower bound on `semigroups` to 0.16.2.
+
 5.3.1 [2018.07.02]
 ------------------
 * Fix a regression introduced in `semigroupoids-5.3` in which some modules

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -140,7 +140,7 @@ library
     base                >= 4.3     && < 5,
     base-orphans        >= 0.8     && < 1,
     bifunctors          >= 5       && < 6,
-    semigroups          >= 0.8.3.1 && < 1,
+    semigroups          >= 0.16.2  && < 1,
     template-haskell,
     transformers        >= 0.2     && < 0.6,
     transformers-compat >= 0.5     && < 0.7

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -140,7 +140,6 @@ library
     base                >= 4.3     && < 5,
     base-orphans        >= 0.8     && < 1,
     bifunctors          >= 5       && < 6,
-    semigroups          >= 0.16.2  && < 1,
     template-haskell,
     transformers        >= 0.2     && < 0.6,
     transformers-compat >= 0.5     && < 0.7
@@ -150,6 +149,9 @@ library
 
   if impl(ghc >= 7.2 && < 7.6)
     build-depends: ghc-prim
+
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups >= 0.16.2 && < 1
 
   if flag(containers)
     build-depends: containers >= 0.3 && < 0.7

--- a/src/Data/Functor/Bind/Class.hs
+++ b/src/Data/Functor/Bind/Class.hs
@@ -6,10 +6,6 @@
 {-# LANGUAGE EmptyCase #-}
 #endif
 
-#ifndef MIN_VERSION_semigroups
-#define MIN_VERSION_semigroups(x,y,z) 1
-#endif
-
 #if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
@@ -726,11 +722,9 @@ instance Biapply (,) where
   (f, g) <<.>> (a, b) = (f a, g b)
   {-# INLINE (<<.>>) #-}
 
-#if MIN_VERSION_semigroups(0,16,2)
 instance Biapply Arg where
   Arg f g <<.>> Arg a b = Arg (f a) (g b)
   {-# INLINE (<<.>>) #-}
-#endif
 
 instance Semigroup x => Biapply ((,,) x) where
   (x, f, g) <<.>> (x', a, b) = (x <> x', f a, g b)

--- a/src/Data/Semigroup/Foldable/Class.hs
+++ b/src/Data/Semigroup/Foldable/Class.hs
@@ -4,10 +4,6 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#ifndef MIN_VERSION_semigroups
-#define MIN_VERSION_semigroups(x,y,z) 0
-#endif
-
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -138,10 +134,8 @@ class Bifoldable t => Bifoldable1 t where
   bifoldMap1 f g = maybe (error "bifoldMap1") id . getOption . bifoldMap (Option . Just . f) (Option . Just . g)
   {-# INLINE bifoldMap1 #-}
 
-#if MIN_VERSION_semigroups(0,16,2)
 instance Bifoldable1 Arg where
   bifoldMap1 f g (Arg a b) = f a <> g b
-#endif
 
 instance Bifoldable1 Either where
   bifoldMap1 f _ (Left a) = f a

--- a/src/Data/Semigroup/Traversable/Class.hs
+++ b/src/Data/Semigroup/Traversable/Class.hs
@@ -80,10 +80,8 @@ class (Bifoldable1 t, Bitraversable t) => Bitraversable1 t where
   {-# MINIMAL bitraverse1 | bisequence1 #-}
 #endif
 
-#if MIN_VERSION_semigroups(0,16,2)
 instance Bitraversable1 Arg where
   bitraverse1 f g (Arg a b) = Arg <$> f a <.> g b
-#endif
 
 instance Bitraversable1 Either where
   bitraverse1 f _ (Left a) = Left <$> f a


### PR DESCRIPTION
The two commits first bump it to 0.16.2 for CPP reduction, then conditionalise it on having an old GHC.