### PR TITLE
Improve performance of NonEmpty functions

### DIFF
--- a/src/Data/Semigroup/Foldable/Class.hs
+++ b/src/Data/Semigroup/Foldable/Class.hs
@@ -244,8 +244,7 @@ instance (Foldable1 f, Foldable1 g) => Foldable1 (Functor.Sum f g) where
   foldMap1 f (Functor.InR y) = foldMap1 f y
 
 instance Foldable1 NonEmpty where
-  foldMap1 f (a :| []) = f a
-  foldMap1 f (a :| b : bs) = f a <> foldMap1 f (b :| bs)
+  foldMap1 f (a :| as) = foldr (\b g x -> f x <> g b) f as a
   toNonEmpty = id
 
 instance Foldable1 ((,) a) where

--- a/src/Data/Semigroup/Traversable/Class.hs
+++ b/src/Data/Semigroup/Traversable/Class.hs
@@ -226,8 +226,7 @@ instance Traversable1 Tree where
 #endif
 
 instance Traversable1 NonEmpty where
-  traverse1 f (a :| []) = (:|[]) <$> f a
-  traverse1 f (a :| (b: bs)) = (\a' (b':| bs') -> a' :| b': bs') <$> f a <.> traverse1 f (b :| bs)
+  traverse1 f (a :| as) = foldr (\b g x -> (\a' (b':| bs') -> a' :| b': bs') <$> f x <.> g b) (fmap (:|[]) . f) as a
 
 instance Traversable1 ((,) a) where
   traverse1 f (a, b) = (,) a <$> f b


### PR DESCRIPTION
Currently, the `foldMap1` and `traverse1` functions for `NonEmpty` make a lot of unnecessary intermediate lists. Refactor the code to avoid all such intermediate lists for `foldMap1`, and half of them for `traverse1` (removing the remaining half for `traverse1` would be more complicated and probably require a new datatype, so I'll save it for a later PR.)