### PR TITLE
Add NonEmptyVector instances

### DIFF
--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -136,6 +136,14 @@ flag unordered-containers
   default: True
   manual: True
 
+flag nonempty-vector
+  description:
+    You can disable the use of the `vector` and `nonempty-vector` package using `-f-nonempty-vector`.
+    .
+    Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+  default: True
+  manual: True
+
 library
   build-depends:
     base                >= 4.3     && < 5,
@@ -172,6 +180,10 @@ library
   if flag(unordered-containers)
     build-depends: hashable >= 1.1  && < 1.4,
                    unordered-containers >= 0.2  && < 0.3
+
+  if flag(nonempty-vector) && impl(ghc >= 8.0)
+    build-depends: nonempty-vector >= 0.2 && < 0.3,
+                   vector >= 0.12 && < 0.13
 
   hs-source-dirs: src
 

--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -82,6 +82,11 @@ import qualified Data.HashMap.Lazy as HashMap
 import Prelude (Eq)
 #endif
 
+#ifdef MIN_VERSION_nonempty_vector
+import Data.Vector (Vector)
+import Data.Vector.NonEmpty (NonEmptyVector)
+#endif
+
 #ifdef MIN_VERSION_generic_deriving
 import Generics.Deriving.Base
 #else
@@ -210,6 +215,14 @@ instance Alt Seq where
 #ifdef MIN_VERSION_unordered_containers
 instance (Hashable k, Eq k) => Alt (HashMap k) where
   (<!>) = HashMap.union
+#endif
+
+#ifdef MIN_VERSION_nonempty_vector
+instance Alt Vector where
+  (<!>) = (<|>)
+
+instance Alt NonEmptyVector where
+  (<!>) = (<>)
 #endif
 
 instance Alt NonEmpty where

--- a/src/Data/Functor/Bind/Class.hs
+++ b/src/Data/Functor/Bind/Class.hs
@@ -137,6 +137,11 @@ import Control.Comonad.Trans.Traced
 ($>) = flip (<$)
 #endif
 
+#ifdef MIN_VERSION_nonempty_vector
+import Data.Vector (Vector)
+import Data.Vector.NonEmpty (NonEmptyVector)
+#endif
+
 infixl 1 >>-
 infixl 4 <.>, <., .>
 
@@ -333,6 +338,17 @@ instance (Hashable k, Eq k) => Apply (HashMap k) where
   (<.>) = HashMap.intersectionWith id
 #endif
 
+#ifdef MIN_VERSION_nonempty_vector
+instance Apply Vector where
+  (<.>) = (<*>)
+  (<. ) = (<* )
+  ( .>) = ( *>)
+
+instance Apply NonEmptyVector where
+  (<.>) = (<*>)
+  (<. ) = (<* )
+  ( .>) = ( *>)
+#endif
 -- MaybeT is _not_ the same as Compose f Maybe
 instance (Functor m, Monad m) => Apply (MaybeT m) where
   (<.>) = apDefault
@@ -693,6 +709,14 @@ instance (Hashable k, Eq k) => Bind (HashMap k) where
     case HashMap.lookup k (f a) of
       Just b -> [(k,b)]
       Nothing -> []
+#endif
+
+#ifdef MIN_VERSION_nonempty_vector
+instance Bind Vector where
+  (>>-) = (>>=)
+
+instance Bind NonEmptyVector where
+  (>>-) = (>>=)
 #endif
 
 instance Bind Down where Down a >>- f = f a

--- a/src/Data/Functor/Plus.hs
+++ b/src/Data/Functor/Plus.hs
@@ -66,6 +66,10 @@ import Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as HashMap
 #endif
 
+#ifdef MIN_VERSION_nonempty_vector
+import Data.Vector (Vector)
+#endif
+
 #ifdef MIN_VERSION_generic_deriving
 import Generics.Deriving.Base
 #else
@@ -129,6 +133,11 @@ instance Plus Seq where
 #ifdef MIN_VERSION_unordered_containers
 instance (Hashable k, Eq k) => Plus (HashMap k) where
   zero = HashMap.empty
+#endif
+
+#ifdef MIN_VERSION_nonempty_vector
+instance Plus Vector where
+  zero = empty
 #endif
 
 instance Alternative f => Plus (WrappedApplicative f) where

--- a/src/Data/Semigroup/Foldable/Class.hs
+++ b/src/Data/Semigroup/Foldable/Class.hs
@@ -66,6 +66,12 @@ import Generics.Deriving.Base
 import GHC.Generics
 #endif
 
+#ifdef MIN_VERSION_nonempty_vector
+import qualified Data.Vector as V
+import Data.Vector.NonEmpty (NonEmptyVector)
+import qualified Data.Vector.NonEmpty as NEV
+#endif
+
 import Prelude hiding (foldr)
 
 class Foldable t => Foldable1 t where
@@ -124,6 +130,7 @@ instance Foldable1 V1 where
 
 instance (Foldable1 f, Foldable1 g) => Foldable1 (f :.: g) where
   foldMap1 f (Comp1 m) = foldMap1 (foldMap1 f) m
+
 
 class Bifoldable t => Bifoldable1 t where
   bifold1 :: Semigroup m => t m m -> m
@@ -254,3 +261,10 @@ instance Foldable1 ((,) a) where
 instance Foldable1 g => Foldable1 (Joker g a) where
   foldMap1 g = foldMap1 g . runJoker
   {-# INLINE foldMap1 #-}
+
+#ifdef MIN_VERSION_nonempty_vector
+instance Foldable1 NonEmptyVector where
+  foldMap1 f v = case NEV.uncons v of
+    ~(a, t) | V.null t -> f a
+    ~(a, t) -> f a <> foldMap1 f (NEV.unsafeFromVector t)
+#endif

--- a/src/Data/Semigroup/Traversable/Class.hs
+++ b/src/Data/Semigroup/Traversable/Class.hs
@@ -67,6 +67,13 @@ import Generics.Deriving.Base
 import GHC.Generics
 #endif
 
+#ifdef MIN_VERSION_nonempty_vector
+import qualified Data.Vector as V
+import Data.Vector.NonEmpty (NonEmptyVector)
+import qualified Data.Vector.NonEmpty as NEV
+#endif
+
+
 class (Bifoldable1 t, Bitraversable t) => Bitraversable1 t where
   bitraverse1 :: Apply f => (a -> f b) -> (c -> f d) -> t a c -> f (t b d)
   bitraverse1 f g  = bisequence1 . bimap f g
@@ -228,6 +235,13 @@ instance Traversable1 Tree where
 instance Traversable1 NonEmpty where
   traverse1 f (a :| []) = (:|[]) <$> f a
   traverse1 f (a :| (b: bs)) = (\a' (b':| bs') -> a' :| b': bs') <$> f a <.> traverse1 f (b :| bs)
+
+#ifdef MIN_VERSION_nonempty_vector
+instance Traversable1 NonEmptyVector where
+  traverse1 f v = case NEV.uncons v of
+    ~(a, t) | V.null t -> NEV.singleton <$> f a
+    ~(a, t) -> NEV.cons <$> f a <.> traverse1 f (NEV.unsafeFromVector t)
+#endif
 
 instance Traversable1 ((,) a) where
   traverse1 f (a, b) = (,) a <$> f b


### PR DESCRIPTION
This PR gets us the following instances: 

For `Vector`: 

- `Plus`
- `Extend`
- `Bind`
- `Apply`

For `NonEmptyVector`: 

- `Extend`
- `Bind`
- `Apply`
- `Foldable1`
- `Traversable1`
