### PR TITLE
Bikeshed all the things

### DIFF
--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -176,12 +176,12 @@ library
   hs-source-dirs: src
 
   exposed-modules:
-    Data.Bifunctor.Apply
-    Data.Functor.Alt
-    Data.Functor.Apply
-    Data.Functor.Bind
-    Data.Functor.Bind.Class
-    Data.Functor.Bind.Trans
+    Data.Bifunctor.Semiapplicative
+    Data.Functor.Semialternative
+    Data.Functor.Semiapplicative
+    Data.Functor.Semimonad
+    Data.Functor.Semimonad.Class
+    Data.Functor.Semimonad.Trans
     Data.Functor.Extend
     Data.Functor.Plus
     Data.Groupoid

--- a/src/Data/Bifunctor/Semiapplicative.hs
+++ b/src/Data/Bifunctor/Semiapplicative.hs
@@ -9,31 +9,31 @@
 -- Portability :  portable
 --
 ----------------------------------------------------------------------------
-module Data.Bifunctor.Apply (
+module Data.Bifunctor.Semiapplicative (
   -- * Biappliable bifunctors
     Bifunctor(..)
-  , Biapply(..)
+  , Bisemiapplicative(..)
   , (<<$>>)
   , (<<..>>)
   , bilift2
   , bilift3
   ) where
 
-import Data.Functor.Bind.Class
+import Data.Functor.Semimonad.Class
 import Data.Biapplicative
 
 infixl 4 <<..>>
 
-(<<..>>) :: Biapply p => p a c -> p (a -> b) (c -> d) -> p b d
+(<<..>>) :: Bisemiapplicative p => p a c -> p (a -> b) (c -> d) -> p b d
 (<<..>>) = bilift2 (flip id) (flip id)
 {-# INLINE (<<..>>) #-}
 
 -- | Lift binary functions
-bilift2 :: Biapply w => (a -> b -> c) -> (d -> e -> f) -> w a d -> w b e -> w c f
+bilift2 :: Bisemiapplicative w => (a -> b -> c) -> (d -> e -> f) -> w a d -> w b e -> w c f
 bilift2 f g a b = bimap f g <<$>> a <<.>> b
 {-# INLINE bilift2 #-}
 
 -- | Lift ternary functions
-bilift3 :: Biapply w => (a -> b -> c -> d) -> (e -> f -> g -> h) -> w a e -> w b f -> w c g -> w d h
+bilift3 :: Bisemiapplicative w => (a -> b -> c -> d) -> (e -> f -> g -> h) -> w a e -> w b f -> w c g -> w d h
 bilift3 f g a b c = bimap f g <<$>> a <<.>> b <<.>> c
 {-# INLINE bilift3 #-}

--- a/src/Data/Functor/Extend.hs
+++ b/src/Data/Functor/Extend.hs
@@ -209,7 +209,7 @@ instance Extend f => Extend (Monoid.Alt f) where
   extended f = Monoid.Alt . extended (f . Monoid.Alt) . Monoid.getAlt
 #endif
 
--- in GHC 8.6 we'll have to deal with Apply f => Apply (Ap f) the same way
+-- in GHC 8.6 we'll have to deal with Semiapplicative f => Semiapplicative (Ap f) the same way
 instance Extend Semigroup.First where
   extended f w@Semigroup.First{} = Semigroup.First (f w)
 

--- a/src/Data/Functor/Plus.hs
+++ b/src/Data/Functor/Plus.hs
@@ -16,7 +16,7 @@
 ----------------------------------------------------------------------------
 module Data.Functor.Plus
   ( Plus(..)
-  , module Data.Functor.Alt
+  , module Data.Functor.Semialternative
   ) where
 
 import Control.Applicative hiding (some, many)
@@ -38,9 +38,9 @@ import qualified Control.Monad.Trans.Writer.Strict as Strict
 import qualified Control.Monad.Trans.RWS.Lazy as Lazy
 import qualified Control.Monad.Trans.State.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
-import Data.Functor.Apply
-import Data.Functor.Alt
-import Data.Functor.Bind
+import Data.Functor.Semiapplicative
+import Data.Functor.Semialternative
+import Data.Functor.Semimonad
 import Data.Functor.Compose
 import Data.Functor.Product
 import Data.Functor.Reverse
@@ -79,7 +79,7 @@ import GHC.Generics
 --
 -- If extended to an 'Alternative' then 'zero' should equal 'empty'.
 
-class Alt f => Plus f where
+class Semialternative f => Plus f where
   zero :: f a
 
 instance Plus Proxy where
@@ -140,16 +140,16 @@ instance Plus f => Plus (IdentityT f) where
 instance Plus f => Plus (ReaderT e f) where
   zero = ReaderT $ \_ -> zero
 
-instance (Bind f, Monad f) => Plus (MaybeT f) where
+instance (Semimonad f, Monad f) => Plus (MaybeT f) where
   zero = MaybeT $ return zero
 
-instance (Bind f, Monad f, Error e) => Plus (ErrorT e f) where
+instance (Semimonad f, Monad f, Error e) => Plus (ErrorT e f) where
   zero = ErrorT $ return $ Left noMsg
 
-instance (Bind f, Monad f, Semigroup e, Monoid e) => Plus (ExceptT e f) where
+instance (Semimonad f, Monad f, Semigroup e, Monoid e) => Plus (ExceptT e f) where
   zero = ExceptT $ return $ Left mempty
 
-instance (Apply f, Applicative f) => Plus (ListT f) where
+instance (Semiapplicative f, Applicative f) => Plus (ListT f) where
   zero = ListT $ pure []
 
 instance Plus f => Plus (Strict.StateT e f) where

--- a/src/Data/Functor/Semialternative.hs
+++ b/src/Data/Functor/Semialternative.hs
@@ -13,7 +13,7 @@
 {-# options_ghc -fno-warn-deprecations #-}
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Data.Functor.Alt
+-- Module      :  Data.Functor.Semialternative
 -- Copyright   :  (C) 2011-2015 Edward Kmett
 -- License     :  BSD-style (see the file LICENSE)
 --
@@ -22,10 +22,10 @@
 -- Portability :  portable
 --
 ----------------------------------------------------------------------------
-module Data.Functor.Alt
-  ( Alt(..)
+module Data.Functor.Semialternative
+  ( Semialternative(..)
   , optional
-  , module Data.Functor.Apply
+  , module Data.Functor.Semiapplicative
   ) where
 
 import Control.Applicative hiding (some, many, optional)
@@ -46,8 +46,8 @@ import qualified Control.Monad.Trans.Writer.Strict as Strict
 import qualified Control.Monad.Trans.RWS.Lazy as Lazy
 import qualified Control.Monad.Trans.State.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
-import Data.Functor.Apply
-import Data.Functor.Bind
+import Data.Functor.Semiapplicative
+import Data.Functor.Semimonad
 import Data.Functor.Compose
 import Data.Functor.Product
 import Data.Functor.Reverse
@@ -96,9 +96,9 @@ infixl 3 <!>
 -- > <!> is associative:             (a <!> b) <!> c = a <!> (b <!> c)
 -- > <$> left-distributes over <!>:  f <$> (a <!> b) = (f <$> a) <!> (f <$> b)
 --
--- If extended to an 'Alternative' then '<!>' should equal '<|>'.
+-- If extended to an 'Semialternativeernative' then '<!>' should equal '<|>'.
 --
--- Ideally, an instance of 'Alt' also satisfies the \"left distributon\" law of
+-- Ideally, an instance of 'Semialternative' also satisfies the \"left distributon\" law of
 -- MonadPlus with respect to '<.>':
 --
 -- > <.> right-distributes over <!>: (a <!> b) <.> c = (a <.> c) <!> (b <.> c)
@@ -108,18 +108,18 @@ infixl 3 <!>
 --
 -- > pure a <!> b = pure a
 --
--- However, this variation cannot be stated purely in terms of the dependencies of 'Alt'.
+-- However, this variation cannot be stated purely in terms of the dependencies of 'Semialternative'.
 --
 -- When and if MonadPlus is successfully refactored, this class should also
 -- be refactored to remove these instances.
 --
--- The right distributive law should extend in the cases where the a 'Bind' or 'Monad' is
+-- The right distributive law should extend in the cases where the a 'Semimonad' or 'Monad' is
 -- provided to yield variations of the right distributive law:
 --
 -- > (m <!> n) >>- f = (m >>- f) <!> (m >>- f)
 -- > (m <!> n) >>= f = (m >>= f) <!> (m >>= f)
 
-class Functor f => Alt f where
+class Functor f => Semialternative f where
   -- | '<|>' without a required @empty@
   (<!>) :: f a -> f a -> f a
 
@@ -134,163 +134,163 @@ class Functor f => Alt f where
           some_v = (:) <$> v <*> many_v
 
 -- | One or none.
-optional :: (Alt f, Applicative f) => f a -> f (Maybe a)
+optional :: (Semialternative f, Applicative f) => f a -> f (Maybe a)
 optional v = Just <$> v <!> pure Nothing
 
-instance (Alt f, Alt g) => Alt (f :*: g) where
+instance (Semialternative f, Semialternative g) => Semialternative (f :*: g) where
   (as :*: bs) <!> (cs :*: ds) = (as <!> cs) :*: (bs <!> ds)
 
 newtype Magic f = Magic { runMagic :: forall a. Applicative f => f a -> f [a] }
 
-instance Alt f => Alt (M1 i c f) where
+instance Semialternative f => Semialternative (M1 i c f) where
   M1 f <!> M1 g = M1 (f <!> g)
   some = runMagic (unsafeCoerce (Magic some :: Magic f))
   many = runMagic (unsafeCoerce (Magic many :: Magic f))
 
-instance Alt f => Alt (Rec1 f) where
+instance Semialternative f => Semialternative (Rec1 f) where
   Rec1 f <!> Rec1 g = Rec1 (f <!> g)
   some = runMagic (unsafeCoerce (Magic some :: Magic f))
   many = runMagic (unsafeCoerce (Magic many :: Magic f))
 
-instance Alt U1 where
+instance Semialternative U1 where
   _ <!> _ = U1
   some _ = U1
   many _ = U1
 
-instance Alt V1 where
+instance Semialternative V1 where
   v <!> u = v `seq` u `seq` undefined
   some v = v `seq` undefined
   many v = v `seq` undefined
 
 #if defined(MIN_VERSION_tagged) || (MIN_VERSION_base(4,7,0))
-instance Alt Proxy where
+instance Semialternative Proxy where
   _ <!> _ = Proxy
   some _ = Proxy
   many _ = Proxy
 #endif
 
-instance Alt (Either a) where
+instance Semialternative (Either a) where
   Left _ <!> b = b
   a      <!> _ = a
 
 -- | This instance does not actually satisfy the ('<.>') right distributive law
 -- It instead satisfies the "Left-Catch" law
-instance Alt IO where
+instance Semialternative IO where
   m <!> n = catch m (go n) where
     go :: x -> SomeException -> x
     go = const
 
-instance Alt [] where
+instance Semialternative [] where
   (<!>) = (++)
 
-instance Alt Maybe where
+instance Semialternative Maybe where
   Nothing <!> b = b
   a       <!> _ = a
 
-instance Alt Option where
+instance Semialternative Option where
   (<!>) = (<|>)
 
-instance MonadPlus m => Alt (WrappedMonad m) where
+instance MonadPlus m => Semialternative (WrappedMonad m) where
   (<!>) = (<|>)
 
-instance ArrowPlus a => Alt (WrappedArrow a b) where
+instance ArrowPlus a => Semialternative (WrappedArrow a b) where
   (<!>) = (<|>)
 
 #ifdef MIN_VERSION_containers
-instance Ord k => Alt (Map k) where
+instance Ord k => Semialternative (Map k) where
   (<!>) = Map.union
 
-instance Alt IntMap where
+instance Semialternative IntMap where
   (<!>) = IntMap.union
 
-instance Alt Seq where
+instance Semialternative Seq where
   (<!>) = mappend
 #endif
 
 #ifdef MIN_VERSION_unordered_containers
-instance (Hashable k, Eq k) => Alt (HashMap k) where
+instance (Hashable k, Eq k) => Semialternative (HashMap k) where
   (<!>) = HashMap.union
 #endif
 
-instance Alt NonEmpty where
+instance Semialternative NonEmpty where
   (a :| as) <!> ~(b :| bs) = a :| (as ++ b : bs)
 
-instance Alternative f => Alt (WrappedApplicative f) where
+instance Alternative f => Semialternative (WrappedApplicative f) where
   WrapApplicative a <!> WrapApplicative b = WrapApplicative (a <|> b)
 
-instance Alt f => Alt (IdentityT f) where
+instance Semialternative f => Semialternative (IdentityT f) where
   IdentityT a <!> IdentityT b = IdentityT (a <!> b)
 
-instance Alt f => Alt (ReaderT e f) where
+instance Semialternative f => Semialternative (ReaderT e f) where
   ReaderT a <!> ReaderT b = ReaderT $ \e -> a e <!> b e
 
-instance (Bind f, Monad f) => Alt (MaybeT f) where
+instance (Semimonad f, Monad f) => Semialternative (MaybeT f) where
   MaybeT a <!> MaybeT b = MaybeT $ do
     v <- a
     case v of
       Nothing -> b
       Just _ -> return v
 
-instance (Bind f, Monad f) => Alt (ErrorT e f) where
+instance (Semimonad f, Monad f) => Semialternative (ErrorT e f) where
   ErrorT m <!> ErrorT n = ErrorT $ do
     a <- m
     case a of
       Left _ -> n
       Right r -> return (Right r)
 
-instance (Bind f, Monad f, Semigroup e) => Alt (ExceptT e f) where
+instance (Semimonad f, Monad f, Semigroup e) => Semialternative (ExceptT e f) where
   ExceptT m <!> ExceptT n = ExceptT $ do
     a <- m
     case a of
       Left e -> liftM (either (Left . (<>) e) Right) n
       Right x -> return (Right x)
 
-instance Apply f => Alt (ListT f) where
+instance Semiapplicative f => Semialternative (ListT f) where
   ListT a <!> ListT b = ListT $ (<!>) <$> a <.> b
 
-instance Alt f => Alt (Strict.StateT e f) where
+instance Semialternative f => Semialternative (Strict.StateT e f) where
   Strict.StateT m <!> Strict.StateT n = Strict.StateT $ \s -> m s <!> n s
 
-instance Alt f => Alt (Lazy.StateT e f) where
+instance Semialternative f => Semialternative (Lazy.StateT e f) where
   Lazy.StateT m <!> Lazy.StateT n = Lazy.StateT $ \s -> m s <!> n s
 
-instance Alt f => Alt (Strict.WriterT w f) where
+instance Semialternative f => Semialternative (Strict.WriterT w f) where
   Strict.WriterT m <!> Strict.WriterT n = Strict.WriterT $ m <!> n
 
-instance Alt f => Alt (Lazy.WriterT w f) where
+instance Semialternative f => Semialternative (Lazy.WriterT w f) where
   Lazy.WriterT m <!> Lazy.WriterT n = Lazy.WriterT $ m <!> n
 
-instance Alt f => Alt (Strict.RWST r w s f) where
+instance Semialternative f => Semialternative (Strict.RWST r w s f) where
   Strict.RWST m <!> Strict.RWST n = Strict.RWST $ \r s -> m r s <!> n r s
 
-instance Alt f => Alt (Lazy.RWST r w s f) where
+instance Semialternative f => Semialternative (Lazy.RWST r w s f) where
   Lazy.RWST m <!> Lazy.RWST n = Lazy.RWST $ \r s -> m r s <!> n r s
 
-instance Alt f => Alt (Backwards f) where
+instance Semialternative f => Semialternative (Backwards f) where
   Backwards a <!> Backwards b = Backwards (a <!> b)
 
-instance (Alt f, Functor g) => Alt (Compose f g) where
+instance (Semialternative f, Functor g) => Semialternative (Compose f g) where
   Compose a <!> Compose b = Compose (a <!> b)
 
-instance Alt f => Alt (Lift f) where
+instance Semialternative f => Semialternative (Lift f) where
   Pure a   <!> _       = Pure a
   Other _  <!> Pure b  = Pure b
   Other a  <!> Other b = Other (a <!> b)
 
-instance (Alt f, Alt g) => Alt (Product f g) where
+instance (Semialternative f, Semialternative g) => Semialternative (Product f g) where
   Pair a1 b1 <!> Pair a2 b2 = Pair (a1 <!> a2) (b1 <!> b2)
 
-instance Alt f => Alt (Reverse f) where
+instance Semialternative f => Semialternative (Reverse f) where
   Reverse a <!> Reverse b = Reverse (a <!> b)
 
-instance Alt Semigroup.First where
+instance Semialternative Semigroup.First where
   (<!>) = (<>)
 
-instance Alt Semigroup.Last where
+instance Semialternative Semigroup.Last where
   (<!>) = (<>)
 
-instance Alt Monoid.First where
+instance Semialternative Monoid.First where
   (<!>) = mappend
 
-instance Alt Monoid.Last where
+instance Semialternative Monoid.Last where
   (<!>) = mappend

--- a/src/Data/Functor/Semiapplicative.hs
+++ b/src/Data/Functor/Semiapplicative.hs
@@ -13,36 +13,36 @@
 -- Portability :  portable
 --
 ----------------------------------------------------------------------------
-module Data.Functor.Apply (
+module Data.Functor.Semiapplicative (
   -- * Functors
     Functor(..)
   , (<$>)     -- :: Functor f => (a -> b) -> f a -> f b
   , ( $>)     -- :: Functor f => f a -> b -> f b
 
-  -- * Apply - a strong lax semimonoidal endofunctor
+  -- * Semiapplicative - a strong lax semimonoidal endofunctor
 
-  , Apply(..)
-  , (<..>)    -- :: Apply w => w a -> w (a -> b) -> w b
-  , liftF3    -- :: Apply w => (a -> b -> c -> d) -> w a -> w b -> w c -> w d
+  , Semiapplicative(..)
+  , (<..>)    -- :: Semiapplicative w => w a -> w (a -> b) -> w b
+  , liftF3    -- :: Semiapplicative w => (a -> b -> c -> d) -> w a -> w b -> w c -> w d
 
   -- * Wrappers
   , WrappedApplicative(..)
-  , MaybeApply(..)
+  , MaybeSemiapplicative(..)
   ) where
 
 import Control.Comonad
-import Data.Functor.Bind.Class
+import Data.Functor.Semimonad.Class
 
 infixl 4 <..>
 
 -- | A variant of '<.>' with the arguments reversed.
-(<..>) :: Apply w => w a -> w (a -> b) -> w b
+(<..>) :: Semiapplicative w => w a -> w (a -> b) -> w b
 (<..>) = liftF2 (flip id)
 {-# INLINE (<..>) #-}
 
 
 -- | Lift a ternary function into a comonad with zipping
-liftF3 :: Apply w => (a -> b -> c -> d) -> w a -> w b -> w c -> w d
+liftF3 :: Semiapplicative w => (a -> b -> c -> d) -> w a -> w b -> w c -> w d
 liftF3 f a b c = f <$> a <.> b <.> c
 {-# INLINE liftF3 #-}
 

--- a/src/Data/Functor/Semimonad.hs
+++ b/src/Data/Functor/Semimonad.hs
@@ -17,20 +17,20 @@
 -- Portability :  portable
 --
 ----------------------------------------------------------------------------
-module Data.Functor.Bind (
+module Data.Functor.Semimonad (
   -- * Functors
     Functor(..)
   , (<$>)     -- :: Functor f => (a -> b) -> f a -> f b
   , ( $>)     -- :: Functor f => f a -> b -> f b
-  -- * Applyable functors
-  , Apply(..)
-  , (<..>)    -- :: Apply w => w a -> w (a -> b) -> w b
-  , liftF3    -- :: Apply w => (a -> b -> c -> d) -> w a -> w b -> w c -> w d
+  -- * Semiapplicativeable functors
+  , Semiapplicative(..)
+  , (<..>)    -- :: Semiapplicative w => w a -> w (a -> b) -> w b
+  , liftF3    -- :: Semiapplicative w => (a -> b -> c -> d) -> w a -> w b -> w c -> w d
   -- * Wrappers
   , WrappedApplicative(..)
-  , MaybeApply(..)
-  -- * Bindable functors
-  , Bind(..)
+  , MaybeSemiapplicative(..)
+  -- * Semimonadable functors
+  , Semimonad(..)
   , (-<<)
   , (-<-)
   , (->-)
@@ -38,18 +38,18 @@ module Data.Functor.Bind (
   , returning
   ) where
 
-import Data.Functor.Apply
-import Data.Functor.Bind.Class
+import Data.Functor.Semiapplicative
+import Data.Functor.Semimonad.Class
 
 infixr 1 -<<, -<-, ->-
 
-(-<<) :: Bind m => (a -> m b) -> m a -> m b
+(-<<) :: Semimonad m => (a -> m b) -> m a -> m b
 (-<<) = flip (>>-)
 
-(->-) :: Bind m => (a -> m b) -> (b -> m c) -> a -> m c
+(->-) :: Semimonad m => (a -> m b) -> (b -> m c) -> a -> m c
 f ->- g = \a -> f a >>- g
 
-(-<-) :: Bind m => (b -> m c) -> (a -> m b) -> a -> m c
+(-<-) :: Semimonad m => (b -> m c) -> (a -> m b) -> a -> m c
 g -<- f = \a -> f a >>- g
 
 

--- a/src/Data/Functor/Semimonad/Class.hs
+++ b/src/Data/Functor/Semimonad/Class.hs
@@ -31,18 +31,18 @@
 -- classes here rather than in a package upstream. Otherwise we'd get
 -- orphaned heads for many instances on the types in @transformers@ and @bifunctors@.
 ----------------------------------------------------------------------------
-module Data.Functor.Bind.Class (
-  -- * Applyable functors
-    Apply(..)
+module Data.Functor.Semimonad.Class (
+  -- * Semiapplicativeable functors
+    Semiapplicative(..)
   -- * Wrappers
   , WrappedApplicative(..)
-  , MaybeApply(..)
-  -- * Bindable functors
-  , Bind(..)
+  , MaybeSemiapplicative(..)
+  -- * Semimonadable functors
+  , Semimonad(..)
   , apDefault
   , returning
   -- * Biappliable bifunctors
-  , Biapply(..)
+  , Bisemiapplicative(..)
   ) where
 
 import Data.Semigroup
@@ -160,7 +160,7 @@ infixl 4 <.>, <., .>
 -- (mf '<$>' m) '.>' (nf '<$>' n) = nf '<$>' (m '.>' n)
 -- (mf '<$>' m) '<.' (nf '<$>' n) = mf '<$>' (m '<.' n)
 -- @
-class Functor f => Apply f where
+class Functor f => Semiapplicative f where
   (<.>) :: f (a -> b) -> f a -> f b
   (<.>) = liftF2 id
 
@@ -182,53 +182,53 @@ class Functor f => Apply f where
 #endif
 
 #ifdef MIN_VERSION_tagged
-instance Apply (Tagged a) where
+instance Semiapplicative (Tagged a) where
   (<.>) = (<*>)
   (<.) = (<*)
   (.>) = (*>)
 #endif
 
 #if defined(MIN_VERSION_tagged) || MIN_VERSION_base(4,7,0)
-instance Apply Proxy where
+instance Semiapplicative Proxy where
   (<.>) = (<*>)
   (<.) = (<*)
   (.>) = (*>)
 #endif
 
-instance Apply f => Apply (Backwards f) where
+instance Semiapplicative f => Semiapplicative (Backwards f) where
   Backwards f <.> Backwards a = Backwards (flip id <$> a <.> f)
 
-instance (Apply f, Apply g) => Apply (Compose f g) where
+instance (Semiapplicative f, Semiapplicative g) => Semiapplicative (Compose f g) where
   Compose f <.> Compose x = Compose ((<.>) <$> f <.> x)
 
--- | A 'Constant f' is not 'Applicative' unless its 'f' is a 'Monoid', but it is an instance of 'Apply'
-instance Semigroup f => Apply (Constant f) where
+-- | A 'Constant f' is not 'Applicative' unless its 'f' is a 'Monoid', but it is an instance of 'Semiapplicative'
+instance Semigroup f => Semiapplicative (Constant f) where
   Constant a <.> Constant b = Constant (a <> b)
   Constant a <.  Constant b = Constant (a <> b)
   Constant a  .> Constant b = Constant (a <> b)
 
-instance Apply f => Apply (Lift f) where
+instance Semiapplicative f => Semiapplicative (Lift f) where
   Pure f  <.> Pure x  = Pure (f x)
   Pure f  <.> Other y = Other (f <$> y)
   Other f <.> Pure x  = Other (($ x) <$> f)
   Other f <.> Other y = Other (f <.> y)
 
-instance (Apply f, Apply g) => Apply (Functor.Product f g) where
+instance (Semiapplicative f, Semiapplicative g) => Semiapplicative (Functor.Product f g) where
   Functor.Pair f g <.> Functor.Pair x y = Functor.Pair (f <.> x) (g <.> y)
 
-instance Apply f => Apply (Reverse f) where
+instance Semiapplicative f => Semiapplicative (Reverse f) where
   Reverse a <.> Reverse b = Reverse (a <.> b)
 
--- | A '(,) m' is not 'Applicative' unless its 'm' is a 'Monoid', but it is an instance of 'Apply'
-instance Semigroup m => Apply ((,)m) where
+-- | A '(,) m' is not 'Applicative' unless its 'm' is a 'Monoid', but it is an instance of 'Semiapplicative'
+instance Semigroup m => Semiapplicative ((,)m) where
   (m, f) <.> (n, a) = (m <> n, f a)
   (m, a) <.  (n, _) = (m <> n, a)
   (m, _)  .> (n, b) = (m <> n, b)
 
-instance Apply NonEmpty where
+instance Semiapplicative NonEmpty where
   (<.>) = ap
 
-instance Apply (Either a) where
+instance Semiapplicative (Either a) where
   Left a  <.> _       = Left a
   Right _ <.> Left a  = Left a
   Right f <.> Right b = Right (f b)
@@ -241,163 +241,163 @@ instance Apply (Either a) where
   Right _  .> Left a  = Left a
   Right _  .> Right b = Right b
 
--- | A 'Const m' is not 'Applicative' unless its 'm' is a 'Monoid', but it is an instance of 'Apply'
-instance Semigroup m => Apply (Const m) where
+-- | A 'Const m' is not 'Applicative' unless its 'm' is a 'Monoid', but it is an instance of 'Semiapplicative'
+instance Semigroup m => Semiapplicative (Const m) where
   Const m <.> Const n = Const (m <> n)
   Const m <.  Const n = Const (m <> n)
   Const m  .> Const n = Const (m <> n)
 
-instance Apply ((->)m) where
+instance Semiapplicative ((->)m) where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
 
-instance Apply ZipList where
+instance Semiapplicative ZipList where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
 
-instance Apply [] where
+instance Semiapplicative [] where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
 
-instance Apply IO where
+instance Semiapplicative IO where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
 
-instance Apply Maybe where
+instance Semiapplicative Maybe where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
 
-instance Apply Option where
+instance Semiapplicative Option where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
 
-instance Apply Identity where
+instance Semiapplicative Identity where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
 
-instance Apply w => Apply (IdentityT w) where
+instance Semiapplicative w => Semiapplicative (IdentityT w) where
   IdentityT wa <.> IdentityT wb = IdentityT (wa <.> wb)
 
-instance Monad m => Apply (WrappedMonad m) where
+instance Monad m => Semiapplicative (WrappedMonad m) where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
 
-instance Arrow a => Apply (WrappedArrow a b) where
+instance Arrow a => Semiapplicative (WrappedArrow a b) where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
 
 #if MIN_VERSION_base(4,4,0)
-instance Apply Complex where
+instance Semiapplicative Complex where
   (a :+ b) <.> (c :+ d) = a c :+ b d
 #endif
 
 -- Applicative Q was only added in template-haskell 2.7 (GHC 7.4), so
 -- define in terms of Monad instead.
-instance Apply Q where
+instance Semiapplicative Q where
   (<.>) = ap
 
 #ifdef MIN_VERSION_containers
--- | A 'Map k' is not 'Applicative', but it is an instance of 'Apply'
-instance Ord k => Apply (Map k) where
+-- | A 'Map k' is not 'Applicative', but it is an instance of 'Semiapplicative'
+instance Ord k => Semiapplicative (Map k) where
   (<.>) = Map.intersectionWith id
   (<. ) = Map.intersectionWith const
   ( .>) = Map.intersectionWith (const id)
 
--- | An 'IntMap' is not 'Applicative', but it is an instance of 'Apply'
-instance Apply IntMap where
+-- | An 'IntMap' is not 'Applicative', but it is an instance of 'Semiapplicative'
+instance Semiapplicative IntMap where
   (<.>) = IntMap.intersectionWith id
   (<. ) = IntMap.intersectionWith const
   ( .>) = IntMap.intersectionWith (const id)
 
-instance Apply Seq where
+instance Semiapplicative Seq where
   (<.>) = ap
 
-instance Apply Tree where
+instance Semiapplicative Tree where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
 #endif
 
 #ifdef MIN_VERSION_unordered_containers
--- | A 'HashMap k' is not 'Applicative', but it is an instance of 'Apply'
-instance (Hashable k, Eq k) => Apply (HashMap k) where
+-- | A 'HashMap k' is not 'Applicative', but it is an instance of 'Semiapplicative'
+instance (Hashable k, Eq k) => Semiapplicative (HashMap k) where
   (<.>) = HashMap.intersectionWith id
 #endif
 
 -- MaybeT is _not_ the same as Compose f Maybe
-instance (Functor m, Monad m) => Apply (MaybeT m) where
+instance (Functor m, Monad m) => Semiapplicative (MaybeT m) where
   (<.>) = apDefault
 
 -- ErrorT e is _not_ the same as Compose f (Either e)
-instance (Functor m, Monad m) => Apply (ErrorT e m) where
+instance (Functor m, Monad m) => Semiapplicative (ErrorT e m) where
   (<.>) = apDefault
 
-instance (Functor m, Monad m) => Apply (ExceptT e m) where
+instance (Functor m, Monad m) => Semiapplicative (ExceptT e m) where
   (<.>) = apDefault
 
-instance Apply m => Apply (ReaderT e m) where
+instance Semiapplicative m => Semiapplicative (ReaderT e m) where
   ReaderT f <.> ReaderT a = ReaderT $ \e -> f e <.> a e
 
-instance Apply m => Apply (ListT m) where
+instance Semiapplicative m => Semiapplicative (ListT m) where
   ListT f <.> ListT a = ListT $ (<.>) <$> f <.> a
 
 -- unfortunately, WriterT has its wrapped product in the wrong order to just use (<.>) instead of flap
--- | A 'WriterT w m' is not 'Applicative' unless its 'w' is a 'Monoid', but it is an instance of 'Apply'
-instance (Apply m, Semigroup w) => Apply (Strict.WriterT w m) where
+-- | A 'WriterT w m' is not 'Applicative' unless its 'w' is a 'Monoid', but it is an instance of 'Semiapplicative'
+instance (Semiapplicative m, Semigroup w) => Semiapplicative (Strict.WriterT w m) where
   Strict.WriterT f <.> Strict.WriterT a = Strict.WriterT $ flap <$> f <.> a where
     flap (x,m) (y,n) = (x y, m <> n)
 
--- | A 'WriterT w m' is not 'Applicative' unless its 'w' is a 'Monoid', but it is an instance of 'Apply'
-instance (Apply m, Semigroup w) => Apply (Lazy.WriterT w m) where
+-- | A 'WriterT w m' is not 'Applicative' unless its 'w' is a 'Monoid', but it is an instance of 'Semiapplicative'
+instance (Semiapplicative m, Semigroup w) => Semiapplicative (Lazy.WriterT w m) where
   Lazy.WriterT f <.> Lazy.WriterT a = Lazy.WriterT $ flap <$> f <.> a where
     flap ~(x,m) ~(y,n) = (x y, m <> n)
 
-instance Bind m => Apply (Strict.StateT s m) where
+instance Semimonad m => Semiapplicative (Strict.StateT s m) where
   (<.>) = apDefault
 
-instance Bind m => Apply (Lazy.StateT s m) where
+instance Semimonad m => Semiapplicative (Lazy.StateT s m) where
   (<.>) = apDefault
 
--- | An 'RWST r w s m' is not 'Applicative' unless its 'w' is a 'Monoid', but it is an instance of 'Apply'
-instance (Bind m, Semigroup w) => Apply (Strict.RWST r w s m) where
+-- | An 'RWST r w s m' is not 'Applicative' unless its 'w' is a 'Monoid', but it is an instance of 'Semiapplicative'
+instance (Semimonad m, Semigroup w) => Semiapplicative (Strict.RWST r w s m) where
   (<.>) = apDefault
 
--- | An 'RWST r w s m' is not 'Applicative' unless its 'w' is a 'Monoid', but it is an instance of 'Apply'
-instance (Bind m, Semigroup w) => Apply (Lazy.RWST r w s m) where
+-- | An 'RWST r w s m' is not 'Applicative' unless its 'w' is a 'Monoid', but it is an instance of 'Semiapplicative'
+instance (Semimonad m, Semigroup w) => Semiapplicative (Lazy.RWST r w s m) where
   (<.>) = apDefault
 
-instance Apply (ContT r m) where
+instance Semiapplicative (ContT r m) where
   ContT f <.> ContT v = ContT $ \k -> f $ \g -> v (k . g)
 
 #ifdef MIN_VERSION_comonad
--- | An 'EnvT e w' is not 'Applicative' unless its 'e' is a 'Monoid', but it is an instance of 'Apply'
-instance (Semigroup e, Apply w) => Apply (EnvT e w) where
+-- | An 'EnvT e w' is not 'Applicative' unless its 'e' is a 'Monoid', but it is an instance of 'Semiapplicative'
+instance (Semigroup e, Semiapplicative w) => Semiapplicative (EnvT e w) where
   EnvT ef wf <.> EnvT ea wa = EnvT (ef <> ea) (wf <.> wa)
 
--- | A 'StoreT s w' is not 'Applicative' unless its 's' is a 'Monoid', but it is an instance of 'Apply'
-instance (Apply w, Semigroup s) => Apply (StoreT s w) where
+-- | A 'StoreT s w' is not 'Applicative' unless its 's' is a 'Monoid', but it is an instance of 'Semiapplicative'
+instance (Semiapplicative w, Semigroup s) => Semiapplicative (StoreT s w) where
   StoreT ff m <.> StoreT fa n = StoreT ((<*>) <$> ff <.> fa) (m <> n)
 
-instance Apply w => Apply (TracedT m w) where
+instance Semiapplicative w => Semiapplicative (TracedT m w) where
   TracedT wf <.> TracedT wa = TracedT (ap <$> wf <.> wa)
 #endif
 
--- | Wrap an 'Applicative' to be used as a member of 'Apply'
+-- | Wrap an 'Applicative' to be used as a member of 'Semiapplicative'
 newtype WrappedApplicative f a = WrapApplicative { unwrapApplicative :: f a }
 
 instance Functor f => Functor (WrappedApplicative f) where
   fmap f (WrapApplicative a) = WrapApplicative (f <$> a)
 
-instance Applicative f => Apply (WrappedApplicative f) where
+instance Applicative f => Semiapplicative (WrappedApplicative f) where
   WrapApplicative f <.> WrapApplicative a = WrapApplicative (f <*> a)
   WrapApplicative a <.  WrapApplicative b = WrapApplicative (a <*  b)
   WrapApplicative a  .> WrapApplicative b = WrapApplicative (a  *> b)
@@ -412,84 +412,84 @@ instance Alternative f => Alternative (WrappedApplicative f) where
   empty = WrapApplicative empty
   WrapApplicative a <|> WrapApplicative b = WrapApplicative (a <|> b)
 
--- | Transform an Apply into an Applicative by adding a unit.
-newtype MaybeApply f a = MaybeApply { runMaybeApply :: Either (f a) a }
+-- | Transform an Semiapplicative into an Applicative by adding a unit.
+newtype MaybeSemiapplicative f a = MaybeSemiapplicative { runMaybeSemiapplicative :: Either (f a) a }
 
-instance Functor f => Functor (MaybeApply f) where
-  fmap f (MaybeApply (Right a)) = MaybeApply (Right (f     a ))
-  fmap f (MaybeApply (Left fa)) = MaybeApply (Left  (f <$> fa))
+instance Functor f => Functor (MaybeSemiapplicative f) where
+  fmap f (MaybeSemiapplicative (Right a)) = MaybeSemiapplicative (Right (f     a ))
+  fmap f (MaybeSemiapplicative (Left fa)) = MaybeSemiapplicative (Left  (f <$> fa))
 
-instance Apply f => Apply (MaybeApply f) where
-  MaybeApply (Right f) <.> MaybeApply (Right a) = MaybeApply (Right (f        a ))
-  MaybeApply (Right f) <.> MaybeApply (Left fa) = MaybeApply (Left  (f    <$> fa))
-  MaybeApply (Left ff) <.> MaybeApply (Right a) = MaybeApply (Left  (($a) <$> ff))
-  MaybeApply (Left ff) <.> MaybeApply (Left fa) = MaybeApply (Left  (ff   <.> fa))
+instance Semiapplicative f => Semiapplicative (MaybeSemiapplicative f) where
+  MaybeSemiapplicative (Right f) <.> MaybeSemiapplicative (Right a) = MaybeSemiapplicative (Right (f        a ))
+  MaybeSemiapplicative (Right f) <.> MaybeSemiapplicative (Left fa) = MaybeSemiapplicative (Left  (f    <$> fa))
+  MaybeSemiapplicative (Left ff) <.> MaybeSemiapplicative (Right a) = MaybeSemiapplicative (Left  (($a) <$> ff))
+  MaybeSemiapplicative (Left ff) <.> MaybeSemiapplicative (Left fa) = MaybeSemiapplicative (Left  (ff   <.> fa))
 
-  MaybeApply a         <. MaybeApply (Right _) = MaybeApply a
-  MaybeApply (Right a) <. MaybeApply (Left fb) = MaybeApply (Left (a  <$ fb))
-  MaybeApply (Left fa) <. MaybeApply (Left fb) = MaybeApply (Left (fa <. fb))
+  MaybeSemiapplicative a         <. MaybeSemiapplicative (Right _) = MaybeSemiapplicative a
+  MaybeSemiapplicative (Right a) <. MaybeSemiapplicative (Left fb) = MaybeSemiapplicative (Left (a  <$ fb))
+  MaybeSemiapplicative (Left fa) <. MaybeSemiapplicative (Left fb) = MaybeSemiapplicative (Left (fa <. fb))
 
-  MaybeApply (Right _) .> MaybeApply b = MaybeApply b
-  MaybeApply (Left fa) .> MaybeApply (Right b) = MaybeApply (Left (fa $> b ))
-  MaybeApply (Left fa) .> MaybeApply (Left fb) = MaybeApply (Left (fa .> fb))
+  MaybeSemiapplicative (Right _) .> MaybeSemiapplicative b = MaybeSemiapplicative b
+  MaybeSemiapplicative (Left fa) .> MaybeSemiapplicative (Right b) = MaybeSemiapplicative (Left (fa $> b ))
+  MaybeSemiapplicative (Left fa) .> MaybeSemiapplicative (Left fb) = MaybeSemiapplicative (Left (fa .> fb))
 
-instance Apply f => Applicative (MaybeApply f) where
-  pure a = MaybeApply (Right a)
+instance Semiapplicative f => Applicative (MaybeSemiapplicative f) where
+  pure a = MaybeSemiapplicative (Right a)
   (<*>) = (<.>)
   (<* ) = (<. )
   ( *>) = ( .>)
 
-instance Extend f => Extend (MaybeApply f) where
-  duplicated w@(MaybeApply Right{}) = MaybeApply (Right w)
-  duplicated (MaybeApply (Left fa)) = MaybeApply (Left (extended (MaybeApply . Left) fa))
+instance Extend f => Extend (MaybeSemiapplicative f) where
+  duplicated w@(MaybeSemiapplicative Right{}) = MaybeSemiapplicative (Right w)
+  duplicated (MaybeSemiapplicative (Left fa)) = MaybeSemiapplicative (Left (extended (MaybeSemiapplicative . Left) fa))
 
 #ifdef MIN_VERSION_comonad
-instance Comonad f => Comonad (MaybeApply f) where
-  duplicate w@(MaybeApply Right{}) = MaybeApply (Right w)
-  duplicate (MaybeApply (Left fa)) = MaybeApply (Left (extend (MaybeApply . Left) fa))
-  extract (MaybeApply (Left fa)) = extract fa
-  extract (MaybeApply (Right a)) = a
+instance Comonad f => Comonad (MaybeSemiapplicative f) where
+  duplicate w@(MaybeSemiapplicative Right{}) = MaybeSemiapplicative (Right w)
+  duplicate (MaybeSemiapplicative (Left fa)) = MaybeSemiapplicative (Left (extend (MaybeSemiapplicative . Left) fa))
+  extract (MaybeSemiapplicative (Left fa)) = extract fa
+  extract (MaybeSemiapplicative (Right a)) = a
 
-instance Apply (Cokleisli w a) where
+instance Semiapplicative (Cokleisli w a) where
   Cokleisli f <.> Cokleisli a = Cokleisli (\w -> (f w) (a w))
 #endif
 
-instance Apply Down where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative Down where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
 
-instance Apply Monoid.Sum where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
-instance Apply Monoid.Product where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
-instance Apply Monoid.Dual where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
-instance Apply Monoid.First where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
-instance Apply Monoid.Last where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative Monoid.Sum where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative Monoid.Product where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative Monoid.Dual where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative Monoid.First where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative Monoid.Last where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
 #if MIN_VERSION_base(4,8,0)
-deriving instance Apply f => Apply (Monoid.Alt f)
+deriving instance Semiapplicative f => Semiapplicative (Monoid.Alt f)
 #endif
--- in GHC 8.6 we'll have to deal with Apply f => Apply (Ap f) the same way
-instance Apply Semigroup.First where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
-instance Apply Semigroup.Last where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
-instance Apply Semigroup.Min where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
-instance Apply Semigroup.Max where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+-- in GHC 8.6 we'll have to deal with Semiapplicative f => Semiapplicative (Ap f) the same way
+instance Semiapplicative Semigroup.First where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative Semigroup.Last where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative Semigroup.Min where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative Semigroup.Max where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
 
-instance (Apply f, Apply g) => Apply (f :*: g) where
+instance (Semiapplicative f, Semiapplicative g) => Semiapplicative (f :*: g) where
   (a :*: b) <.> (c :*: d) = (a <.> c) :*: (b <.> d)
 
-deriving instance Apply f => Apply (M1 i t f)
-deriving instance Apply f => Apply (Rec1 f)
+deriving instance Semiapplicative f => Semiapplicative (M1 i t f)
+deriving instance Semiapplicative f => Semiapplicative (Rec1 f)
 
-instance (Apply f, Apply g) => Apply (f :.: g) where
+instance (Semiapplicative f, Semiapplicative g) => Semiapplicative (f :.: g) where
   Comp1 m <.> Comp1 n = Comp1 $ (<.>) <$> m <.> n
 
-instance Apply U1 where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative U1 where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
 
--- | A 'K1 i c' is not 'Applicative' unless its 'c' is a 'Monoid', but it is an instance of 'Apply'
-instance Semigroup c => Apply (K1 i c) where
+-- | A 'K1 i c' is not 'Applicative' unless its 'c' is a 'Monoid', but it is an instance of 'Semiapplicative'
+instance Semigroup c => Semiapplicative (K1 i c) where
   K1 a <.> K1 b = K1 (a <> b)
   K1 a <.  K1 b = K1 (a <> b)
   K1 a  .> K1 b = K1 (a <> b)
-instance Apply Par1 where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
+instance Semiapplicative Par1 where (<.>)=(<*>);(.>)=(*>);(<.)=(<*)
 
--- | A 'V1' is not 'Applicative', but it is an instance of 'Apply'
-instance Apply Generics.V1 where
+-- | A 'V1' is not 'Applicative', but it is an instance of 'Semiapplicative'
+instance Semiapplicative Generics.V1 where
 #if __GLASGOW_HASKELL__ >= 708
   e <.> _ = case e of {}
 #else
@@ -519,7 +519,7 @@ instance Apply Generics.V1 where
 -- > associativity of (->-): (f ->- g) ->- h = f ->- (g ->- h)
 --
 
-class Apply m => Bind m where
+class Semiapplicative m => Semimonad m where
   (>>-) :: m a -> (a -> m b) -> m b
   m >>- f = join (fmap f m)
 
@@ -533,135 +533,135 @@ class Apply m => Bind m where
 returning :: Functor f => f a -> (a -> b) -> f b
 returning = flip fmap
 
-apDefault :: Bind f => f (a -> b) -> f a -> f b
+apDefault :: Semimonad f => f (a -> b) -> f a -> f b
 apDefault f x = f >>- \f' -> f' <$> x
 
--- | A '(,) m' is not a 'Monad' unless its 'm' is a 'Monoid', but it is an instance of 'Bind'
-instance Semigroup m => Bind ((,)m) where
+-- | A '(,) m' is not a 'Monad' unless its 'm' is a 'Monoid', but it is an instance of 'Semimonad'
+instance Semigroup m => Semimonad ((,)m) where
   ~(m, a) >>- f = let (n, b) = f a in (m <> n, b)
 
 #ifdef MIN_VERSION_tagged
-instance Bind (Tagged a) where
+instance Semimonad (Tagged a) where
   Tagged a >>- f = f a
   join (Tagged a) = a
 #endif
 
 #if defined(MIN_VERSION_tagged) || MIN_VERSION_base(4,7,0)
-instance Bind Proxy where
+instance Semimonad Proxy where
   _ >>- _ = Proxy
   join _ = Proxy
 #endif
 
-instance Bind (Either a) where
+instance Semimonad (Either a) where
   Left a  >>- _ = Left a
   Right a >>- f = f a
 
-instance (Bind f, Bind g) => Bind (Functor.Product f g) where
+instance (Semimonad f, Semimonad g) => Semimonad (Functor.Product f g) where
   Functor.Pair m n >>- f = Functor.Pair (m >>- fstP . f) (n >>- sndP . f) where
     fstP (Functor.Pair a _) = a
     sndP (Functor.Pair _ b) = b
 
-instance Bind ((->)m) where
+instance Semimonad ((->)m) where
   f >>- g = \e -> g (f e) e
 
-instance Bind [] where
+instance Semimonad [] where
   (>>-) = (>>=)
 
-instance Bind NonEmpty where
+instance Semimonad NonEmpty where
   (>>-) = (>>=)
 
-instance Bind IO where
+instance Semimonad IO where
   (>>-) = (>>=)
 
-instance Bind Maybe where
+instance Semimonad Maybe where
   (>>-) = (>>=)
 
-instance Bind Option where
+instance Semimonad Option where
   (>>-) = (>>=)
 
-instance Bind Identity where
+instance Semimonad Identity where
   (>>-) = (>>=)
 
-instance Bind Q where
+instance Semimonad Q where
   (>>-) = (>>=)
 
-instance Bind m => Bind (IdentityT m) where
+instance Semimonad m => Semimonad (IdentityT m) where
   IdentityT m >>- f = IdentityT (m >>- runIdentityT . f)
 
-instance Monad m => Bind (WrappedMonad m) where
+instance Monad m => Semimonad (WrappedMonad m) where
   WrapMonad m >>- f = WrapMonad $ m >>= unwrapMonad . f
 
-instance (Functor m, Monad m) => Bind (MaybeT m) where
+instance (Functor m, Monad m) => Semimonad (MaybeT m) where
   (>>-) = (>>=) -- distributive law requires Monad to inject @Nothing@
 
-instance (Apply m, Monad m) => Bind (ListT m) where
+instance (Semiapplicative m, Monad m) => Semimonad (ListT m) where
   (>>-) = (>>=) -- distributive law requires Monad to inject @[]@
 
-instance (Functor m, Monad m) => Bind (ErrorT e m) where
+instance (Functor m, Monad m) => Semimonad (ErrorT e m) where
   m >>- k = ErrorT $ do
     a <- runErrorT m
     case a of
       Left l -> return (Left l)
       Right r -> runErrorT (k r)
 
-instance (Functor m, Monad m) => Bind (ExceptT e m) where
+instance (Functor m, Monad m) => Semimonad (ExceptT e m) where
   m >>- k = ExceptT $ do
     a <- runExceptT m
     case a of
       Left l -> return (Left l)
       Right r -> runExceptT (k r)
 
-instance Bind m => Bind (ReaderT e m) where
+instance Semimonad m => Semimonad (ReaderT e m) where
   ReaderT m >>- f = ReaderT $ \e -> m e >>- \x -> runReaderT (f x) e
 
--- | A 'WriterT w m' is not a 'Monad' unless its 'w' is a 'Monoid', but it is an instance of 'Bind'
-instance (Bind m, Semigroup w) => Bind (Lazy.WriterT w m) where
+-- | A 'WriterT w m' is not a 'Monad' unless its 'w' is a 'Monoid', but it is an instance of 'Semimonad'
+instance (Semimonad m, Semigroup w) => Semimonad (Lazy.WriterT w m) where
   m >>- k = Lazy.WriterT $
     Lazy.runWriterT m >>- \ ~(a, w) ->
     Lazy.runWriterT (k a) `returning` \ ~(b, w') ->
       (b, w <> w')
 
--- | A 'WriterT w m' is not a 'Monad' unless its 'w' is a 'Monoid', but it is an instance of 'Bind'
-instance (Bind m, Semigroup w) => Bind (Strict.WriterT w m) where
+-- | A 'WriterT w m' is not a 'Monad' unless its 'w' is a 'Monoid', but it is an instance of 'Semimonad'
+instance (Semimonad m, Semigroup w) => Semimonad (Strict.WriterT w m) where
   m >>- k = Strict.WriterT $
     Strict.runWriterT m >>- \ (a, w) ->
     Strict.runWriterT (k a) `returning` \ (b, w') ->
       (b, w <> w')
 
-instance Bind m => Bind (Lazy.StateT s m) where
+instance Semimonad m => Semimonad (Lazy.StateT s m) where
   m >>- k = Lazy.StateT $ \s ->
     Lazy.runStateT m s >>- \ ~(a, s') ->
     Lazy.runStateT (k a) s'
 
-instance Bind m => Bind (Strict.StateT s m) where
+instance Semimonad m => Semimonad (Strict.StateT s m) where
   m >>- k = Strict.StateT $ \s ->
     Strict.runStateT m s >>- \ ~(a, s') ->
     Strict.runStateT (k a) s'
 
--- | An 'RWST r w s m' is not a 'Monad' unless its 'w' is a 'Monoid', but it is an instance of 'Bind'
-instance (Bind m, Semigroup w) => Bind (Lazy.RWST r w s m) where
+-- | An 'RWST r w s m' is not a 'Monad' unless its 'w' is a 'Monoid', but it is an instance of 'Semimonad'
+instance (Semimonad m, Semigroup w) => Semimonad (Lazy.RWST r w s m) where
   m >>- k = Lazy.RWST $ \r s ->
     Lazy.runRWST m r s >>- \ ~(a, s', w) ->
     Lazy.runRWST (k a) r s' `returning` \ ~(b, s'', w') ->
       (b, s'', w <> w')
 
--- | An 'RWST r w s m' is not a 'Monad' unless its 'w' is a 'Monoid', but it is an instance of 'Bind'
-instance (Bind m, Semigroup w) => Bind (Strict.RWST r w s m) where
+-- | An 'RWST r w s m' is not a 'Monad' unless its 'w' is a 'Monoid', but it is an instance of 'Semimonad'
+instance (Semimonad m, Semigroup w) => Semimonad (Strict.RWST r w s m) where
   m >>- k = Strict.RWST $ \r s ->
     Strict.runRWST m r s >>- \ (a, s', w) ->
     Strict.runRWST (k a) r s' `returning` \ (b, s'', w') ->
       (b, s'', w <> w')
 
-instance Bind (ContT r m) where
+instance Semimonad (ContT r m) where
   m >>- k = ContT $ \c -> runContT m $ \a -> runContT (k a) c
 
 {-
-instance ArrowApply a => Bind (WrappedArrow a b) where
+instance ArrowSemiapplicative a => Semimonad (WrappedArrow a b) where
   (>>-) = (>>=)
 -}
 
 #if MIN_VERSION_base(4,4,0)
-instance Bind Complex where
+instance Semimonad Complex where
   (a :+ b) >>- f = a' :+ b' where
     a' :+ _  = f a
     _  :+ b' = f b
@@ -669,24 +669,24 @@ instance Bind Complex where
 #endif
 
 #ifdef MIN_VERSION_containers
--- | A 'Map k' is not a 'Monad', but it is an instance of 'Bind'
-instance Ord k => Bind (Map k) where
+-- | A 'Map k' is not a 'Monad', but it is an instance of 'Semimonad'
+instance Ord k => Semimonad (Map k) where
   m >>- f = Map.mapMaybeWithKey (\k -> Map.lookup k . f) m
 
--- | An 'IntMap' is not a 'Monad', but it is an instance of 'Bind'
-instance Bind IntMap where
+-- | An 'IntMap' is not a 'Monad', but it is an instance of 'Semimonad'
+instance Semimonad IntMap where
   m >>- f = IntMap.mapMaybeWithKey (\k -> IntMap.lookup k . f) m
 
-instance Bind Seq where
+instance Semimonad Seq where
   (>>-) = (>>=)
 
-instance Bind Tree where
+instance Semimonad Tree where
   (>>-) = (>>=)
 #endif
 
 #ifdef MIN_VERSION_unordered_containers
--- | A 'HashMap k' is not a 'Monad', but it is an instance of 'Bind'
-instance (Hashable k, Eq k) => Bind (HashMap k) where
+-- | A 'HashMap k' is not a 'Monad', but it is an instance of 'Semimonad'
+instance (Hashable k, Eq k) => Semimonad (HashMap k) where
   -- this is needlessly painful
   m >>- f = HashMap.fromList $ do
     (k, a) <- HashMap.toList m
@@ -695,24 +695,24 @@ instance (Hashable k, Eq k) => Bind (HashMap k) where
       Nothing -> []
 #endif
 
-instance Bind Down where Down a >>- f = f a
+instance Semimonad Down where Down a >>- f = f a
 
-instance Bind Monoid.Sum where (>>-) = (>>=)
-instance Bind Monoid.Product where (>>-) = (>>=)
-instance Bind Monoid.Dual where (>>-) = (>>=)
-instance Bind Monoid.First where (>>-) = (>>=)
-instance Bind Monoid.Last where (>>-) = (>>=)
+instance Semimonad Monoid.Sum where (>>-) = (>>=)
+instance Semimonad Monoid.Product where (>>-) = (>>=)
+instance Semimonad Monoid.Dual where (>>-) = (>>=)
+instance Semimonad Monoid.First where (>>-) = (>>=)
+instance Semimonad Monoid.Last where (>>-) = (>>=)
 #if MIN_VERSION_base(4,8,0)
-instance Bind f => Bind (Monoid.Alt f) where
+instance Semimonad f => Semimonad (Monoid.Alt f) where
   Monoid.Alt m >>- k = Monoid.Alt (m >>- Monoid.getAlt . k)
 #endif
--- in GHC 8.6 we'll have to deal with Bind f => Bind (Ap f) the same way
-instance Bind Semigroup.First where (>>-) = (>>=)
-instance Bind Semigroup.Last where (>>-) = (>>=)
-instance Bind Semigroup.Min where (>>-) = (>>=)
-instance Bind Semigroup.Max where (>>-) = (>>=)
--- | A 'V1' is not a 'Monad', but it is an instance of 'Bind'
-instance Bind Generics.V1 where
+-- in GHC 8.6 we'll have to deal with Semimonad f => Semimonad (Ap f) the same way
+instance Semimonad Semigroup.First where (>>-) = (>>=)
+instance Semimonad Semigroup.Last where (>>-) = (>>=)
+instance Semimonad Semigroup.Min where (>>-) = (>>=)
+instance Semimonad Semigroup.Max where (>>-) = (>>=)
+-- | A 'V1' is not a 'Monad', but it is an instance of 'Semimonad'
+instance Semimonad Generics.V1 where
 #if __GLASGOW_HASKELL__ >= 708
   m >>- _ = case m of {}
 #else
@@ -721,7 +721,7 @@ instance Bind Generics.V1 where
 
 infixl 4 <<.>>, <<., .>>
 
-class Bifunctor p => Biapply p where
+class Bifunctor p => Bisemiapplicative p where
   (<<.>>) :: p (a -> b) (c -> d) -> p a c -> p b d
 
   -- |
@@ -740,54 +740,54 @@ class Bifunctor p => Biapply p where
   a <<. b = bimap const const <<$>> a <<.>> b
   {-# INLINE (<<.) #-}
 
-instance Biapply (,) where
+instance Bisemiapplicative (,) where
   (f, g) <<.>> (a, b) = (f a, g b)
   {-# INLINE (<<.>>) #-}
 
-instance Biapply Arg where
+instance Bisemiapplicative Arg where
   Arg f g <<.>> Arg a b = Arg (f a) (g b)
   {-# INLINE (<<.>>) #-}
 
-instance Semigroup x => Biapply ((,,) x) where
+instance Semigroup x => Bisemiapplicative ((,,) x) where
   (x, f, g) <<.>> (x', a, b) = (x <> x', f a, g b)
   {-# INLINE (<<.>>) #-}
 
-instance (Semigroup x, Semigroup y) => Biapply ((,,,) x y) where
+instance (Semigroup x, Semigroup y) => Bisemiapplicative ((,,,) x y) where
   (x, y, f, g) <<.>> (x', y', a, b) = (x <> x', y <> y', f a, g b)
   {-# INLINE (<<.>>) #-}
 
-instance (Semigroup x, Semigroup y, Semigroup z) => Biapply ((,,,,) x y z) where
+instance (Semigroup x, Semigroup y, Semigroup z) => Bisemiapplicative ((,,,,) x y z) where
   (x, y, z, f, g) <<.>> (x', y', z', a, b) = (x <> x', y <> y', z <> z', f a, g b)
   {-# INLINE (<<.>>) #-}
 
-instance Biapply Const where
+instance Bisemiapplicative Const where
   Const f <<.>> Const x = Const (f x)
   {-# INLINE (<<.>>) #-}
 
 #ifdef MIN_VERSION_tagged
-instance Biapply Tagged where
+instance Bisemiapplicative Tagged where
   Tagged f <<.>> Tagged x = Tagged (f x)
   {-# INLINE (<<.>>) #-}
 #endif
 
-instance (Biapply p, Apply f, Apply g) => Biapply (Biff p f g) where
+instance (Bisemiapplicative p, Semiapplicative f, Semiapplicative g) => Bisemiapplicative (Biff p f g) where
   Biff fg <<.>> Biff xy = Biff (bimap (<.>) (<.>) fg <<.>> xy)
   {-# INLINE (<<.>>) #-}
 
-instance Apply f => Biapply (Clown f) where
+instance Semiapplicative f => Bisemiapplicative (Clown f) where
   Clown fg <<.>> Clown xy = Clown (fg <.> xy)
   {-# INLINE (<<.>>) #-}
 
-instance Biapply p => Biapply (Flip p) where
+instance Bisemiapplicative p => Bisemiapplicative (Flip p) where
   Flip fg <<.>> Flip xy = Flip (fg <<.>> xy)
   {-# INLINE (<<.>>) #-}
 
-instance Apply g => Biapply (Joker g) where
+instance Semiapplicative g => Bisemiapplicative (Joker g) where
   Joker fg <<.>> Joker xy = Joker (fg <.> xy)
   {-# INLINE (<<.>>) #-}
 
 -- orphan mess
-instance Biapply p => Apply (Join p) where
+instance Bisemiapplicative p => Semiapplicative (Join p) where
   Join f <.> Join a = Join (f <<.>> a)
   {-# INLINE (<.>) #-}
   Join a .> Join b = Join (a .>> b)
@@ -795,14 +795,14 @@ instance Biapply p => Apply (Join p) where
   Join a <. Join b = Join (a <<. b)
   {-# INLINE (<.) #-}
 
-instance (Biapply p, Biapply q) => Biapply (Bifunctor.Product p q) where
+instance (Bisemiapplicative p, Bisemiapplicative q) => Bisemiapplicative (Bifunctor.Product p q) where
   Bifunctor.Pair w x <<.>> Bifunctor.Pair y z = Bifunctor.Pair (w <<.>> y) (x <<.>> z)
   {-# INLINE (<<.>>) #-}
 
-instance (Apply f, Biapply p) => Biapply (Tannen f p) where
+instance (Semiapplicative f, Bisemiapplicative p) => Bisemiapplicative (Tannen f p) where
   Tannen fg <<.>> Tannen xy = Tannen ((<<.>>) <$> fg <.> xy)
   {-# INLINE (<<.>>) #-}
 
-instance Biapply p => Biapply (WrappedBifunctor p) where
+instance Bisemiapplicative p => Bisemiapplicative (WrappedBifunctor p) where
   WrapBifunctor fg <<.>> WrapBifunctor xy = WrapBifunctor (fg <<.>> xy)
   {-# INLINE (<<.>>) #-}

--- a/src/Data/Functor/Semimonad/Trans.hs
+++ b/src/Data/Functor/Semimonad/Trans.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Data.Functor.Bind.Trans
+-- Module      :  Data.Functor.Semimonad.Trans
 -- Copyright   :  (C) 2011-2015 Edward Kmett
 -- License     :  BSD-style (see the file LICENSE)
 --
@@ -10,8 +10,8 @@
 -- Portability :  portable
 --
 ----------------------------------------------------------------------------
-module Data.Functor.Bind.Trans (
-  BindTrans(..)
+module Data.Functor.Semimonad.Trans (
+  SemimonadTrans(..)
   ) where
 
 -- import _everything_
@@ -29,40 +29,40 @@ import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.RWS.Strict as Strict
 import qualified Control.Monad.Trans.State.Strict as Strict
 import qualified Control.Monad.Trans.Writer.Strict as Strict
-import Data.Functor.Bind
+import Data.Functor.Semimonad
 import Data.Orphans ()
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup hiding (Product)
 #endif
 import Prelude hiding (id, (.))
 
--- | A subset of monad transformers can transform any 'Bind' as well.
-class MonadTrans t => BindTrans t where
-  liftB :: Bind b => b a -> t b a
+-- | A subset of monad transformers can transform any 'Semimonad' as well.
+class MonadTrans t => SemimonadTrans t where
+  liftB :: Semimonad b => b a -> t b a
 
-instance BindTrans IdentityT where
+instance SemimonadTrans IdentityT where
   liftB = IdentityT
 
-instance BindTrans (ReaderT e) where
+instance SemimonadTrans (ReaderT e) where
   liftB = ReaderT . const
 
-instance Monoid w => BindTrans (Lazy.WriterT w) where
+instance Monoid w => SemimonadTrans (Lazy.WriterT w) where
   liftB = Lazy.WriterT . fmap (\a -> (a, mempty))
 
-instance Monoid w => BindTrans (Strict.WriterT w) where
+instance Monoid w => SemimonadTrans (Strict.WriterT w) where
   liftB = Strict.WriterT . fmap (\a -> (a, mempty))
 
-instance BindTrans (Lazy.StateT s) where
+instance SemimonadTrans (Lazy.StateT s) where
   liftB m = Lazy.StateT $ \s -> fmap (\a -> (a, s)) m
 
-instance BindTrans (Strict.StateT s) where
+instance SemimonadTrans (Strict.StateT s) where
   liftB m = Strict.StateT $ \s -> fmap (\a -> (a, s)) m
 
-instance Monoid w => BindTrans (Lazy.RWST r w s) where
+instance Monoid w => SemimonadTrans (Lazy.RWST r w s) where
   liftB m = Lazy.RWST $ \ _r s -> fmap (\a -> (a, s, mempty)) m
 
-instance Monoid w => BindTrans (Strict.RWST r w s) where
+instance Monoid w => SemimonadTrans (Strict.RWST r w s) where
   liftB m = Strict.RWST $ \ _r s -> fmap (\a -> (a, s, mempty)) m
 
-instance BindTrans (ContT r) where
+instance SemimonadTrans (ContT r) where
   liftB m = ContT (m >>-)

--- a/src/Data/Semigroup/Bifoldable.hs
+++ b/src/Data/Semigroup/Bifoldable.hs
@@ -10,23 +10,23 @@
 --
 ----------------------------------------------------------------------------
 module Data.Semigroup.Bifoldable
-  ( Bifoldable1(..)
-  , bitraverse1_
+  ( NonEmptyBifoldable(..)
+  , bitraverseNE_
   , bifor1_
   , bisequenceA1_
-  , bifoldMapDefault1
+  , bifoldMapDefaultNE
   ) where
 
 import Control.Applicative
 import Data.Bifoldable
-import Data.Functor.Apply
+import Data.Functor.Semiapplicative
 import Data.Semigroup
 import Data.Semigroup.Foldable.Class
 import Prelude hiding (foldr)
 
 newtype Act f a = Act { getAct :: f a }
 
-instance Apply f => Semigroup (Act f a) where
+instance Semiapplicative f => Semigroup (Act f a) where
   Act a <> Act b = Act (a .> b)
   {-# INLINE (<>) #-}
 
@@ -36,23 +36,23 @@ instance Functor f => Functor (Act f) where
   b <$ Act a = Act (b <$ a)
   {-# INLINE (<$) #-}
 
-bitraverse1_ :: (Bifoldable1 t, Apply f) => (a -> f b) -> (c -> f d) -> t a c -> f ()
-bitraverse1_ f g t = getAct (bifoldMap1 (Act . ignore . f) (Act . ignore . g) t)
-{-# INLINE bitraverse1_ #-}
+bitraverseNE_ :: (NonEmptyBifoldable t, Semiapplicative f) => (a -> f b) -> (c -> f d) -> t a c -> f ()
+bitraverseNE_ f g t = getAct (bifoldMapNE (Act . ignore . f) (Act . ignore . g) t)
+{-# INLINE bitraverseNE_ #-}
 
-bifor1_ :: (Bifoldable1 t, Apply f) => t a c -> (a -> f b) -> (c -> f d) -> f ()
-bifor1_ t f g = bitraverse1_ f g t
+bifor1_ :: (NonEmptyBifoldable t, Semiapplicative f) => t a c -> (a -> f b) -> (c -> f d) -> f ()
+bifor1_ t f g = bitraverseNE_ f g t
 {-# INLINE bifor1_ #-}
 
 ignore :: Functor f => f a -> f ()
 ignore = (() <$)
 {-# INLINE ignore #-}
 
-bisequenceA1_ :: (Bifoldable1 t, Apply f) => t (f a) (f b) -> f ()
-bisequenceA1_ t = getAct (bifoldMap1 (Act . ignore) (Act . ignore) t)
+bisequenceA1_ :: (NonEmptyBifoldable t, Semiapplicative f) => t (f a) (f b) -> f ()
+bisequenceA1_ t = getAct (bifoldMapNE (Act . ignore) (Act . ignore) t)
 {-# INLINE bisequenceA1_ #-}
 
--- | Usable default for foldMap, but only if you define bifoldMap1 yourself
-bifoldMapDefault1 :: (Bifoldable1 t, Monoid m) => (a -> m) -> (b -> m) -> t a b -> m
-bifoldMapDefault1 f g = unwrapMonoid . bifoldMap (WrapMonoid . f) (WrapMonoid . g)
-{-# INLINE bifoldMapDefault1 #-}
+-- | Usable default for foldMap, but only if you define bifoldMapNE yourself
+bifoldMapDefaultNE :: (NonEmptyBifoldable t, Monoid m) => (a -> m) -> (b -> m) -> t a b -> m
+bifoldMapDefaultNE f g = unwrapMonoid . bifoldMap (WrapMonoid . f) (WrapMonoid . g)
+{-# INLINE bifoldMapDefaultNE #-}

--- a/src/Data/Semigroup/Bitraversable.hs
+++ b/src/Data/Semigroup/Bitraversable.hs
@@ -10,8 +10,8 @@
 --
 ----------------------------------------------------------------------------
 module Data.Semigroup.Bitraversable
-  ( Bitraversable1(..)
-  , bifoldMap1Default
+  ( NonEmptyBitraversable(..)
+  , bifoldMapNEDefault
   ) where
 
 import Control.Applicative
@@ -20,6 +20,6 @@ import Data.Semigroup
 #endif
 import Data.Semigroup.Traversable.Class
 
-bifoldMap1Default :: (Bitraversable1 t, Semigroup m) => (a -> m) -> (b -> m) -> t a b -> m
-bifoldMap1Default f g = getConst . bitraverse1 (Const . f) (Const . g)
-{-# INLINE bifoldMap1Default #-}
+bifoldMapNEDefault :: (NonEmptyBitraversable t, Semigroup m) => (a -> m) -> (b -> m) -> t a b -> m
+bifoldMapNEDefault f g = getConst . bitraverseNE (Const . f) (Const . g)
+{-# INLINE bifoldMapNEDefault #-}

--- a/src/Data/Semigroup/Foldable.hs
+++ b/src/Data/Semigroup/Foldable.hs
@@ -9,21 +9,21 @@
 --
 ----------------------------------------------------------------------------
 module Data.Semigroup.Foldable
-  ( Foldable1(..)
-  , intercalate1
-  , intercalateMap1
-  , traverse1_
+  ( NonEmptyFoldable(..)
+  , intercalateNE
+  , intercalateMapNE
+  , traverseNE_
   , for1_
   , sequenceA1_
-  , foldMapDefault1
-  , asum1
-  , foldrM1
-  , foldlM1
+  , foldMapDefaultNE
+  , asumNE
+  , foldrMNE
+  , foldlMNE
   ) where
 
 import Data.Foldable
-import Data.Functor.Alt (Alt(..))
-import Data.Functor.Apply
+import Data.Functor.Semialternative (Semialternative(..))
+import Data.Functor.Semiapplicative
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Traversable.Instances ()
 import Data.Semigroup hiding (Product, Sum)
@@ -39,78 +39,78 @@ instance Semigroup a => Semigroup (JoinWith a) where
   JoinWith a <> JoinWith b = JoinWith $ \j -> a j <> j <> b j
 
 -- | Insert an 'm' between each pair of 't m'.  Equivalent to
--- 'intercalateMap1' with 'id' as the second argument.
+-- 'intercalateMapNE' with 'id' as the second argument.
 --
--- >>> intercalate1 ", " $ "hello" :| ["how", "are", "you"]
+-- >>> intercalateNE ", " $ "hello" :| ["how", "are", "you"]
 -- "hello, how, are, you"
 --
--- >>> intercalate1 ", " $ "hello" :| []
+-- >>> intercalateNE ", " $ "hello" :| []
 -- "hello"
 --
--- >>> intercalate1 mempty $ "I" :| ["Am", "Fine", "You?"]
+-- >>> intercalateNE mempty $ "I" :| ["Am", "Fine", "You?"]
 -- "IAmFineYou?"
-intercalate1 :: (Foldable1 t, Semigroup m) => m -> t m -> m
-intercalate1 = flip intercalateMap1 id
-{-# INLINE intercalate1 #-}
+intercalateNE :: (NonEmptyFoldable t, Semigroup m) => m -> t m -> m
+intercalateNE = flip intercalateMapNE id
+{-# INLINE intercalateNE #-}
 
 -- | Insert 'm' between each pair of 'm' derived from 'a'.
 --
--- >>> intercalateMap1 " " show $ True :| [False, True]
+-- >>> intercalateMapNE " " show $ True :| [False, True]
 -- "True False True"
 --
--- >>> intercalateMap1 " " show $ True :| []
+-- >>> intercalateMapNE " " show $ True :| []
 -- "True"
-intercalateMap1 :: (Foldable1 t, Semigroup m) => m -> (a -> m) -> t a -> m
-intercalateMap1 j f = flip joinee j . foldMap1 (JoinWith . const . f)
-{-# INLINE intercalateMap1 #-}
+intercalateMapNE :: (NonEmptyFoldable t, Semigroup m) => m -> (a -> m) -> t a -> m
+intercalateMapNE j f = flip joinee j . foldMapNE (JoinWith . const . f)
+{-# INLINE intercalateMapNE #-}
 
 newtype Act f a = Act { getAct :: f a }
 
-instance Apply f => Semigroup (Act f a) where
+instance Semiapplicative f => Semigroup (Act f a) where
   Act a <> Act b = Act (a .> b)
 
 instance Functor f => Functor (Act f) where
   fmap f (Act a) = Act (f <$> a)
   b <$ Act a = Act (b <$ a)
 
-traverse1_ :: (Foldable1 t, Apply f) => (a -> f b) -> t a -> f ()
-traverse1_ f t = () <$ getAct (foldMap1 (Act . f) t)
-{-# INLINE traverse1_ #-}
+traverseNE_ :: (NonEmptyFoldable t, Semiapplicative f) => (a -> f b) -> t a -> f ()
+traverseNE_ f t = () <$ getAct (foldMapNE (Act . f) t)
+{-# INLINE traverseNE_ #-}
 
-for1_ :: (Foldable1 t, Apply f) => t a -> (a -> f b) -> f ()
-for1_ = flip traverse1_
+for1_ :: (NonEmptyFoldable t, Semiapplicative f) => t a -> (a -> f b) -> f ()
+for1_ = flip traverseNE_
 {-# INLINE for1_ #-}
 
-sequenceA1_ :: (Foldable1 t, Apply f) => t (f a) -> f ()
-sequenceA1_ t = () <$ getAct (foldMap1 Act t)
+sequenceA1_ :: (NonEmptyFoldable t, Semiapplicative f) => t (f a) -> f ()
+sequenceA1_ t = () <$ getAct (foldMapNE Act t)
 {-# INLINE sequenceA1_ #-}
 
--- | Usable default for foldMap, but only if you define foldMap1 yourself
-foldMapDefault1 :: (Foldable1 t, Monoid m) => (a -> m) -> t a -> m
-foldMapDefault1 f = unwrapMonoid . foldMap (WrapMonoid . f)
-{-# INLINE foldMapDefault1 #-}
+-- | Usable default for foldMap, but only if you define foldMapNE yourself
+foldMapDefaultNE :: (NonEmptyFoldable t, Monoid m) => (a -> m) -> t a -> m
+foldMapDefaultNE f = unwrapMonoid . foldMap (WrapMonoid . f)
+{-# INLINE foldMapDefaultNE #-}
 
--- toStream :: Foldable1 t => t a -> Stream a
--- concat1 :: Foldable1 t => t (Stream a) -> Stream a
--- concatMap1 :: Foldable1 t => (a -> Stream b) -> t a -> Stream b
+-- toStream :: NonEmptyFoldable t => t a -> Stream a
+-- concat1 :: NonEmptyFoldable t => t (Stream a) -> Stream a
+-- concatMap1 :: NonEmptyFoldable t => (a -> Stream b) -> t a -> Stream b
 
 newtype Alt_ f a = Alt_ { getAlt_ :: f a }
 
-instance Alt f => Semigroup (Alt_ f a) where
+instance Semialternative f => Semigroup (Alt_ f a) where
   Alt_ a <> Alt_ b = Alt_ (a <!> b)
 
-asum1 :: (Foldable1 t, Alt m) => t (m a) -> m a
-asum1 = getAlt_ . foldMap1 Alt_
-{-# INLINE asum1 #-}
+asumNE :: (NonEmptyFoldable t, Semialternative m) => t (m a) -> m a
+asumNE = getAlt_ . foldMapNE Alt_
+{-# INLINE asumNE #-}
 
 -- | Monadic fold over the elements of a non-empty structure,
 -- associating to the right, i.e. from right to left.
 --
 -- > let g = (=<<) . f
--- > in foldrM1 f (x1 :| [x2, ..., xn]) == x1 `g` (x2 `g` ... (xn-1 `f` xn)...)
+-- > in foldrMNE f (x1 :| [x2, ..., xn]) == x1 `g` (x2 `g` ... (xn-1 `f` xn)...)
 --
-foldrM1 :: (Foldable1 t, Monad m) => (a -> a -> m a) -> t a -> m a
-foldrM1 f = go . toNonEmpty
+foldrMNE :: (NonEmptyFoldable t, Monad m) => (a -> a -> m a) -> t a -> m a
+foldrMNE f = go . toNonEmpty
   where
     g = (=<<) . f
     
@@ -123,9 +123,9 @@ foldrM1 f = go . toNonEmpty
 -- associating to the left, i.e. from left to right.
 --
 -- > let g = flip $ (=<<) . f
--- > in foldlM1 f (x1 :| [x2, ..., xn]) == (...((x1 `f` x2) `g` x2) `g`...) `g` xn
+-- > in foldlMNE f (x1 :| [x2, ..., xn]) == (...((x1 `f` x2) `g` x2) `g`...) `g` xn
 --
-foldlM1 :: (Foldable1 t, Monad m) => (a -> a -> m a) -> t a -> m a
-foldlM1 f t = foldlM f x xs
+foldlMNE :: (NonEmptyFoldable t, Monad m) => (a -> a -> m a) -> t a -> m a
+foldlMNE f t = foldlM f x xs
   where
     x:|xs = toNonEmpty t

--- a/src/Data/Semigroup/Foldable/Class.hs
+++ b/src/Data/Semigroup/Foldable/Class.hs
@@ -15,8 +15,8 @@
 --
 ----------------------------------------------------------------------------
 module Data.Semigroup.Foldable.Class
-  ( Foldable1(..)
-  , Bifoldable1(..)
+  ( NonEmptyFoldable(..)
+  , NonEmptyBifoldable(..)
   ) where
 
 import Control.Applicative
@@ -68,189 +68,189 @@ import GHC.Generics
 
 import Prelude hiding (foldr)
 
-class Foldable t => Foldable1 t where
-  fold1 :: Semigroup m => t m -> m
-  foldMap1 :: Semigroup m => (a -> m) -> t a -> m
+class Foldable t => NonEmptyFoldable t where
+  foldNE :: Semigroup m => t m -> m
+  foldMapNE :: Semigroup m => (a -> m) -> t a -> m
   toNonEmpty :: t a -> NonEmpty a
 
-  foldMap1 f = maybe (error "foldMap1") id . getOption . foldMap (Option . Just . f)
-  fold1 = foldMap1 id
-  toNonEmpty = foldMap1 (:|[])
+  foldMapNE f = maybe (error "foldMapNE") id . getOption . foldMap (Option . Just . f)
+  foldNE = foldMapNE id
+  toNonEmpty = foldMapNE (:|[])
 
-instance Foldable1 Monoid.Sum where
-  foldMap1 f (Monoid.Sum a) = f a
+instance NonEmptyFoldable Monoid.Sum where
+  foldMapNE f (Monoid.Sum a) = f a
 
-instance Foldable1 Monoid.Product where
-  foldMap1 f (Monoid.Product a) = f a
+instance NonEmptyFoldable Monoid.Product where
+  foldMapNE f (Monoid.Product a) = f a
 
-instance Foldable1 Monoid.Dual where
-  foldMap1 f (Monoid.Dual a) = f a
+instance NonEmptyFoldable Monoid.Dual where
+  foldMapNE f (Monoid.Dual a) = f a
 
 #if MIN_VERSION_base(4,8,0)
-instance Foldable1 f => Foldable1 (Monoid.Alt f) where
-  foldMap1 g (Monoid.Alt m) = foldMap1 g m
+instance NonEmptyFoldable f => NonEmptyFoldable (Monoid.Alt f) where
+  foldMapNE g (Monoid.Alt m) = foldMapNE g m
 #endif
 
-instance Foldable1 Semigroup.First where
-  foldMap1 f (Semigroup.First a) = f a
+instance NonEmptyFoldable Semigroup.First where
+  foldMapNE f (Semigroup.First a) = f a
 
-instance Foldable1 Semigroup.Last where
-  foldMap1 f (Semigroup.Last a) = f a
+instance NonEmptyFoldable Semigroup.Last where
+  foldMapNE f (Semigroup.Last a) = f a
 
-instance Foldable1 Semigroup.Min where
-  foldMap1 f (Semigroup.Min a) = f a
+instance NonEmptyFoldable Semigroup.Min where
+  foldMapNE f (Semigroup.Min a) = f a
 
-instance Foldable1 Semigroup.Max where
-  foldMap1 f (Semigroup.Max a) = f a
+instance NonEmptyFoldable Semigroup.Max where
+  foldMapNE f (Semigroup.Max a) = f a
 
-instance Foldable1 f => Foldable1 (Rec1 f) where
-  foldMap1 f (Rec1 as) = foldMap1 f as
+instance NonEmptyFoldable f => NonEmptyFoldable (Rec1 f) where
+  foldMapNE f (Rec1 as) = foldMapNE f as
 
-instance Foldable1 f => Foldable1 (M1 i c f) where
-  foldMap1 f (M1 as) = foldMap1 f as
+instance NonEmptyFoldable f => NonEmptyFoldable (M1 i c f) where
+  foldMapNE f (M1 as) = foldMapNE f as
 
-instance Foldable1 Par1 where
-  foldMap1 f (Par1 a) = f a
+instance NonEmptyFoldable Par1 where
+  foldMapNE f (Par1 a) = f a
 
-instance (Foldable1 f, Foldable1 g) => Foldable1 (f :*: g) where
-  foldMap1 f (as :*: bs) = foldMap1 f as <> foldMap1 f bs
+instance (NonEmptyFoldable f, NonEmptyFoldable g) => NonEmptyFoldable (f :*: g) where
+  foldMapNE f (as :*: bs) = foldMapNE f as <> foldMapNE f bs
 
-instance (Foldable1 f, Foldable1 g) => Foldable1 (f :+: g) where
-  foldMap1 f (L1 as) = foldMap1 f as
-  foldMap1 f (R1 bs) = foldMap1 f bs
+instance (NonEmptyFoldable f, NonEmptyFoldable g) => NonEmptyFoldable (f :+: g) where
+  foldMapNE f (L1 as) = foldMapNE f as
+  foldMapNE f (R1 bs) = foldMapNE f bs
 
-instance Foldable1 V1 where
-  foldMap1 _ v = v `seq` undefined
+instance NonEmptyFoldable V1 where
+  foldMapNE _ v = v `seq` undefined
 
-instance (Foldable1 f, Foldable1 g) => Foldable1 (f :.: g) where
-  foldMap1 f (Comp1 m) = foldMap1 (foldMap1 f) m
+instance (NonEmptyFoldable f, NonEmptyFoldable g) => NonEmptyFoldable (f :.: g) where
+  foldMapNE f (Comp1 m) = foldMapNE (foldMapNE f) m
 
-class Bifoldable t => Bifoldable1 t where
-  bifold1 :: Semigroup m => t m m -> m
-  bifold1 = bifoldMap1 id id
-  {-# INLINE bifold1 #-}
+class Bifoldable t => NonEmptyBifoldable t where
+  bifoldNE :: Semigroup m => t m m -> m
+  bifoldNE = bifoldMapNE id id
+  {-# INLINE bifoldNE #-}
 
-  bifoldMap1 :: Semigroup m => (a -> m) -> (b -> m) -> t a b -> m
-  bifoldMap1 f g = maybe (error "bifoldMap1") id . getOption . bifoldMap (Option . Just . f) (Option . Just . g)
-  {-# INLINE bifoldMap1 #-}
+  bifoldMapNE :: Semigroup m => (a -> m) -> (b -> m) -> t a b -> m
+  bifoldMapNE f g = maybe (error "bifoldMapNE") id . getOption . bifoldMap (Option . Just . f) (Option . Just . g)
+  {-# INLINE bifoldMapNE #-}
 
-instance Bifoldable1 Arg where
-  bifoldMap1 f g (Arg a b) = f a <> g b
+instance NonEmptyBifoldable Arg where
+  bifoldMapNE f g (Arg a b) = f a <> g b
 
-instance Bifoldable1 Either where
-  bifoldMap1 f _ (Left a) = f a
-  bifoldMap1 _ g (Right b) = g b
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyBifoldable Either where
+  bifoldMapNE f _ (Left a) = f a
+  bifoldMapNE _ g (Right b) = g b
+  {-# INLINE bifoldMapNE #-}
 
-instance Bifoldable1 (,) where
-  bifoldMap1 f g (a, b) = f a <> g b
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyBifoldable (,) where
+  bifoldMapNE f g (a, b) = f a <> g b
+  {-# INLINE bifoldMapNE #-}
 
-instance Bifoldable1 ((,,) x) where
-  bifoldMap1 f g (_,a,b) = f a <> g b
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyBifoldable ((,,) x) where
+  bifoldMapNE f g (_,a,b) = f a <> g b
+  {-# INLINE bifoldMapNE #-}
 
-instance Bifoldable1 ((,,,) x y) where
-  bifoldMap1 f g (_,_,a,b) = f a <> g b
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyBifoldable ((,,,) x y) where
+  bifoldMapNE f g (_,_,a,b) = f a <> g b
+  {-# INLINE bifoldMapNE #-}
 
-instance Bifoldable1 ((,,,,) x y z) where
-  bifoldMap1 f g (_,_,_,a,b) = f a <> g b
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyBifoldable ((,,,,) x y z) where
+  bifoldMapNE f g (_,_,_,a,b) = f a <> g b
+  {-# INLINE bifoldMapNE #-}
 
-instance Bifoldable1 Const where
-  bifoldMap1 f _ (Const a) = f a
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyBifoldable Const where
+  bifoldMapNE f _ (Const a) = f a
+  {-# INLINE bifoldMapNE #-}
 
 #ifdef MIN_VERSION_tagged
-instance Bifoldable1 Tagged where
-  bifoldMap1 _ g (Tagged b) = g b
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyBifoldable Tagged where
+  bifoldMapNE _ g (Tagged b) = g b
+  {-# INLINE bifoldMapNE #-}
 #endif
 
-instance (Bifoldable1 p, Foldable1 f, Foldable1 g) => Bifoldable1 (Biff p f g) where
-  bifoldMap1 f g = bifoldMap1 (foldMap1 f) (foldMap1 g) . runBiff
-  {-# INLINE bifoldMap1 #-}
+instance (NonEmptyBifoldable p, NonEmptyFoldable f, NonEmptyFoldable g) => NonEmptyBifoldable (Biff p f g) where
+  bifoldMapNE f g = bifoldMapNE (foldMapNE f) (foldMapNE g) . runBiff
+  {-# INLINE bifoldMapNE #-}
 
-instance Foldable1 f => Bifoldable1 (Clown f) where
-  bifoldMap1 f _ = foldMap1 f . runClown
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyFoldable f => NonEmptyBifoldable (Clown f) where
+  bifoldMapNE f _ = foldMapNE f . runClown
+  {-# INLINE bifoldMapNE #-}
 
-instance Bifoldable1 p => Bifoldable1 (Flip p) where
-  bifoldMap1 f g = bifoldMap1 g f . runFlip
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyBifoldable p => NonEmptyBifoldable (Flip p) where
+  bifoldMapNE f g = bifoldMapNE g f . runFlip
+  {-# INLINE bifoldMapNE #-}
 
-instance Bifoldable1 p => Foldable1 (Join p) where
-  foldMap1 f (Join a) = bifoldMap1 f f a
-  {-# INLINE foldMap1 #-}
+instance NonEmptyBifoldable p => NonEmptyFoldable (Join p) where
+  foldMapNE f (Join a) = bifoldMapNE f f a
+  {-# INLINE foldMapNE #-}
 
-instance Foldable1 g => Bifoldable1 (Joker g) where
-  bifoldMap1 _ g = foldMap1 g . runJoker
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyFoldable g => NonEmptyBifoldable (Joker g) where
+  bifoldMapNE _ g = foldMapNE g . runJoker
+  {-# INLINE bifoldMapNE #-}
 
-instance (Bifoldable1 f, Bifoldable1 g) => Bifoldable1 (Bifunctor.Product f g) where
-  bifoldMap1 f g (Bifunctor.Pair x y) = bifoldMap1 f g x <> bifoldMap1 f g y
-  {-# INLINE bifoldMap1 #-}
+instance (NonEmptyBifoldable f, NonEmptyBifoldable g) => NonEmptyBifoldable (Bifunctor.Product f g) where
+  bifoldMapNE f g (Bifunctor.Pair x y) = bifoldMapNE f g x <> bifoldMapNE f g y
+  {-# INLINE bifoldMapNE #-}
 
-instance (Foldable1 f, Bifoldable1 p) => Bifoldable1 (Tannen f p) where
-  bifoldMap1 f g = foldMap1 (bifoldMap1 f g) . runTannen
-  {-# INLINE bifoldMap1 #-}
+instance (NonEmptyFoldable f, NonEmptyBifoldable p) => NonEmptyBifoldable (Tannen f p) where
+  bifoldMapNE f g = foldMapNE (bifoldMapNE f g) . runTannen
+  {-# INLINE bifoldMapNE #-}
 
-instance Bifoldable1 p => Bifoldable1 (WrappedBifunctor p) where
-  bifoldMap1 f g = bifoldMap1 f g . unwrapBifunctor
-  {-# INLINE bifoldMap1 #-}
+instance NonEmptyBifoldable p => NonEmptyBifoldable (WrappedBifunctor p) where
+  bifoldMapNE f g = bifoldMapNE f g . unwrapBifunctor
+  {-# INLINE bifoldMapNE #-}
 
 #if MIN_VERSION_base(4,4,0)
-instance Foldable1 Complex where
-  foldMap1 f (a :+ b) = f a <> f b
-  {-# INLINE foldMap1 #-}
+instance NonEmptyFoldable Complex where
+  foldMapNE f (a :+ b) = f a <> f b
+  {-# INLINE foldMapNE #-}
 #endif
 
 #ifdef MIN_VERSION_containers
-instance Foldable1 Tree where
-  foldMap1 f (Node a []) = f a
-  foldMap1 f (Node a (x:xs)) = f a <> foldMap1 (foldMap1 f) (x :| xs)
+instance NonEmptyFoldable Tree where
+  foldMapNE f (Node a []) = f a
+  foldMapNE f (Node a (x:xs)) = f a <> foldMapNE (foldMapNE f) (x :| xs)
 #endif
 
-instance Foldable1 Identity where
-  foldMap1 f = f . runIdentity
+instance NonEmptyFoldable Identity where
+  foldMapNE f = f . runIdentity
 
 #ifdef MIN_VERSION_tagged
-instance Foldable1 (Tagged a) where
-  foldMap1 f (Tagged a) = f a
+instance NonEmptyFoldable (Tagged a) where
+  foldMapNE f (Tagged a) = f a
 #endif
 
-instance Foldable1 m => Foldable1 (IdentityT m) where
-  foldMap1 f = foldMap1 f . runIdentityT
+instance NonEmptyFoldable m => NonEmptyFoldable (IdentityT m) where
+  foldMapNE f = foldMapNE f . runIdentityT
 
-instance Foldable1 f => Foldable1 (Backwards f) where
-  foldMap1 f = foldMap1 f . forwards
+instance NonEmptyFoldable f => NonEmptyFoldable (Backwards f) where
+  foldMapNE f = foldMapNE f . forwards
 
-instance (Foldable1 f, Foldable1 g) => Foldable1 (Compose f g) where
-  foldMap1 f = foldMap1 (foldMap1 f) . getCompose
+instance (NonEmptyFoldable f, NonEmptyFoldable g) => NonEmptyFoldable (Compose f g) where
+  foldMapNE f = foldMapNE (foldMapNE f) . getCompose
 
-instance Foldable1 f => Foldable1 (Lift f) where
-  foldMap1 f (Pure x)  = f x
-  foldMap1 f (Other y) = foldMap1 f y
+instance NonEmptyFoldable f => NonEmptyFoldable (Lift f) where
+  foldMapNE f (Pure x)  = f x
+  foldMapNE f (Other y) = foldMapNE f y
 
-instance (Foldable1 f, Foldable1 g) => Foldable1 (Functor.Product f g) where
-  foldMap1 f (Functor.Pair a b) = foldMap1 f a <> foldMap1 f b
+instance (NonEmptyFoldable f, NonEmptyFoldable g) => NonEmptyFoldable (Functor.Product f g) where
+  foldMapNE f (Functor.Pair a b) = foldMapNE f a <> foldMapNE f b
 
-instance Foldable1 f => Foldable1 (Reverse f) where
-  foldMap1 f = getDual . foldMap1 (Dual . f) . getReverse
+instance NonEmptyFoldable f => NonEmptyFoldable (Reverse f) where
+  foldMapNE f = getDual . foldMapNE (Dual . f) . getReverse
 
-instance (Foldable1 f, Foldable1 g) => Foldable1 (Functor.Sum f g) where
-  foldMap1 f (Functor.InL x) = foldMap1 f x
-  foldMap1 f (Functor.InR y) = foldMap1 f y
+instance (NonEmptyFoldable f, NonEmptyFoldable g) => NonEmptyFoldable (Functor.Sum f g) where
+  foldMapNE f (Functor.InL x) = foldMapNE f x
+  foldMapNE f (Functor.InR y) = foldMapNE f y
 
-instance Foldable1 NonEmpty where
-  foldMap1 f (a :| []) = f a
-  foldMap1 f (a :| b : bs) = f a <> foldMap1 f (b :| bs)
+instance NonEmptyFoldable NonEmpty where
+  foldMapNE f (a :| []) = f a
+  foldMapNE f (a :| b : bs) = f a <> foldMapNE f (b :| bs)
   toNonEmpty = id
 
-instance Foldable1 ((,) a) where
-  foldMap1 f (_, x) = f x
+instance NonEmptyFoldable ((,) a) where
+  foldMapNE f (_, x) = f x
 
-instance Foldable1 g => Foldable1 (Joker g a) where
-  foldMap1 g = foldMap1 g . runJoker
-  {-# INLINE foldMap1 #-}
+instance NonEmptyFoldable g => NonEmptyFoldable (Joker g a) where
+  foldMapNE g = foldMapNE g . runJoker
+  {-# INLINE foldMapNE #-}

--- a/src/Data/Semigroup/Traversable.hs
+++ b/src/Data/Semigroup/Traversable.hs
@@ -10,8 +10,8 @@
 --
 ----------------------------------------------------------------------------
 module Data.Semigroup.Traversable
-  ( Traversable1(..)
-  , foldMap1Default
+  ( NonEmptyTraversable(..)
+  , foldMapNEDefault
   ) where
 
 import Control.Applicative
@@ -20,5 +20,5 @@ import Data.Semigroup
 #endif
 import Data.Semigroup.Traversable.Class
 
-foldMap1Default :: (Traversable1 f, Semigroup m) => (a -> m) -> f a -> m
-foldMap1Default f = getConst . traverse1 (Const . f)
+foldMapNEDefault :: (NonEmptyTraversable f, Semigroup m) => (a -> m) -> f a -> m
+foldMapNEDefault f = getConst . traverseNE (Const . f)

--- a/src/Data/Semigroup/Traversable/Class.hs
+++ b/src/Data/Semigroup/Traversable/Class.hs
@@ -14,8 +14,8 @@
 --
 ----------------------------------------------------------------------------
 module Data.Semigroup.Traversable.Class
-  ( Bitraversable1(..)
-  , Traversable1(..)
+  ( NonEmptyBitraversable(..)
+  , NonEmptyTraversable(..)
   ) where
 
 import Control.Applicative
@@ -32,7 +32,7 @@ import Data.Bifunctor.Join
 import Data.Bifunctor.Product as Bifunctor
 import Data.Bifunctor.Tannen
 import Data.Bifunctor.Wrapped
-import Data.Functor.Apply
+import Data.Functor.Semiapplicative
 import Data.Functor.Compose
 
 import Data.Functor.Identity
@@ -67,197 +67,197 @@ import Generics.Deriving.Base
 import GHC.Generics
 #endif
 
-class (Bifoldable1 t, Bitraversable t) => Bitraversable1 t where
-  bitraverse1 :: Apply f => (a -> f b) -> (c -> f d) -> t a c -> f (t b d)
-  bitraverse1 f g  = bisequence1 . bimap f g
-  {-# INLINE bitraverse1 #-}
+class (NonEmptyBifoldable t, Bitraversable t) => NonEmptyBitraversable t where
+  bitraverseNE :: Semiapplicative f => (a -> f b) -> (c -> f d) -> t a c -> f (t b d)
+  bitraverseNE f g  = bisequenceNE . bimap f g
+  {-# INLINE bitraverseNE #-}
 
-  bisequence1 :: Apply f => t (f a) (f b) -> f (t a b)
-  bisequence1 = bitraverse1 id id
-  {-# INLINE bisequence1 #-}
+  bisequenceNE :: Semiapplicative f => t (f a) (f b) -> f (t a b)
+  bisequenceNE = bitraverseNE id id
+  {-# INLINE bisequenceNE #-}
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
-  {-# MINIMAL bitraverse1 | bisequence1 #-}
+  {-# MINIMAL bitraverseNE | bisequenceNE #-}
 #endif
 
-instance Bitraversable1 Arg where
-  bitraverse1 f g (Arg a b) = Arg <$> f a <.> g b
+instance NonEmptyBitraversable Arg where
+  bitraverseNE f g (Arg a b) = Arg <$> f a <.> g b
 
-instance Bitraversable1 Either where
-  bitraverse1 f _ (Left a) = Left <$> f a
-  bitraverse1 _ g (Right b) = Right <$> g b
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyBitraversable Either where
+  bitraverseNE f _ (Left a) = Left <$> f a
+  bitraverseNE _ g (Right b) = Right <$> g b
+  {-# INLINE bitraverseNE #-}
 
-instance Bitraversable1 (,) where
-  bitraverse1 f g (a, b) = (,) <$> f a <.> g b
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyBitraversable (,) where
+  bitraverseNE f g (a, b) = (,) <$> f a <.> g b
+  {-# INLINE bitraverseNE #-}
 
-instance Bitraversable1 ((,,) x) where
-  bitraverse1 f g (x, a, b) = (,,) x <$> f a <.> g b
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyBitraversable ((,,) x) where
+  bitraverseNE f g (x, a, b) = (,,) x <$> f a <.> g b
+  {-# INLINE bitraverseNE #-}
 
-instance Bitraversable1 ((,,,) x y) where
-  bitraverse1 f g (x, y, a, b) = (,,,) x y <$> f a <.> g b
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyBitraversable ((,,,) x y) where
+  bitraverseNE f g (x, y, a, b) = (,,,) x y <$> f a <.> g b
+  {-# INLINE bitraverseNE #-}
 
-instance Bitraversable1 ((,,,,) x y z) where
-  bitraverse1 f g (x, y, z, a, b) = (,,,,) x y z <$> f a <.> g b
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyBitraversable ((,,,,) x y z) where
+  bitraverseNE f g (x, y, z, a, b) = (,,,,) x y z <$> f a <.> g b
+  {-# INLINE bitraverseNE #-}
 
-instance Bitraversable1 Const where
-  bitraverse1 f _ (Const a) = Const <$> f a
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyBitraversable Const where
+  bitraverseNE f _ (Const a) = Const <$> f a
+  {-# INLINE bitraverseNE #-}
 
 #ifdef MIN_VERSION_tagged
-instance Bitraversable1 Tagged where
-  bitraverse1 _ g (Tagged b) = Tagged <$> g b
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyBitraversable Tagged where
+  bitraverseNE _ g (Tagged b) = Tagged <$> g b
+  {-# INLINE bitraverseNE #-}
 #endif
 
-instance (Bitraversable1 p, Traversable1 f, Traversable1 g) => Bitraversable1 (Biff p f g) where
-  bitraverse1 f g = fmap Biff . bitraverse1 (traverse1 f) (traverse1 g) . runBiff
-  {-# INLINE bitraverse1 #-}
+instance (NonEmptyBitraversable p, NonEmptyTraversable f, NonEmptyTraversable g) => NonEmptyBitraversable (Biff p f g) where
+  bitraverseNE f g = fmap Biff . bitraverseNE (traverseNE f) (traverseNE g) . runBiff
+  {-# INLINE bitraverseNE #-}
 
-instance Traversable1 f => Bitraversable1 (Clown f) where
-  bitraverse1 f _ = fmap Clown . traverse1 f . runClown
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyTraversable f => NonEmptyBitraversable (Clown f) where
+  bitraverseNE f _ = fmap Clown . traverseNE f . runClown
+  {-# INLINE bitraverseNE #-}
 
-instance Bitraversable1 p => Bitraversable1 (Flip p) where
-  bitraverse1 f g = fmap Flip . bitraverse1 g f . runFlip
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyBitraversable p => NonEmptyBitraversable (Flip p) where
+  bitraverseNE f g = fmap Flip . bitraverseNE g f . runFlip
+  {-# INLINE bitraverseNE #-}
 
-instance Bitraversable1 p => Traversable1 (Join p) where
-  traverse1 f (Join a) = fmap Join (bitraverse1 f f a)
-  {-# INLINE traverse1 #-}
-  sequence1 (Join a) = fmap Join (bisequence1 a)
-  {-# INLINE sequence1 #-}
+instance NonEmptyBitraversable p => NonEmptyTraversable (Join p) where
+  traverseNE f (Join a) = fmap Join (bitraverseNE f f a)
+  {-# INLINE traverseNE #-}
+  sequenceNE (Join a) = fmap Join (bisequenceNE a)
+  {-# INLINE sequenceNE #-}
 
-instance Traversable1 g => Bitraversable1 (Joker g) where
-  bitraverse1 _ g = fmap Joker . traverse1 g . runJoker
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyTraversable g => NonEmptyBitraversable (Joker g) where
+  bitraverseNE _ g = fmap Joker . traverseNE g . runJoker
+  {-# INLINE bitraverseNE #-}
 
-instance (Bitraversable1 f, Bitraversable1 g) => Bitraversable1 (Bifunctor.Product f g) where
-  bitraverse1 f g (Bifunctor.Pair x y) = Bifunctor.Pair <$> bitraverse1 f g x <.> bitraverse1 f g y
-  {-# INLINE bitraverse1 #-}
+instance (NonEmptyBitraversable f, NonEmptyBitraversable g) => NonEmptyBitraversable (Bifunctor.Product f g) where
+  bitraverseNE f g (Bifunctor.Pair x y) = Bifunctor.Pair <$> bitraverseNE f g x <.> bitraverseNE f g y
+  {-# INLINE bitraverseNE #-}
 
-instance (Traversable1 f, Bitraversable1 p) => Bitraversable1 (Tannen f p) where
-  bitraverse1 f g = fmap Tannen . traverse1 (bitraverse1 f g) . runTannen
-  {-# INLINE bitraverse1 #-}
+instance (NonEmptyTraversable f, NonEmptyBitraversable p) => NonEmptyBitraversable (Tannen f p) where
+  bitraverseNE f g = fmap Tannen . traverseNE (bitraverseNE f g) . runTannen
+  {-# INLINE bitraverseNE #-}
 
-instance Bitraversable1 p => Bitraversable1 (WrappedBifunctor p) where
-  bitraverse1 f g = fmap WrapBifunctor . bitraverse1 f g . unwrapBifunctor
-  {-# INLINE bitraverse1 #-}
+instance NonEmptyBitraversable p => NonEmptyBitraversable (WrappedBifunctor p) where
+  bitraverseNE f g = fmap WrapBifunctor . bitraverseNE f g . unwrapBifunctor
+  {-# INLINE bitraverseNE #-}
 
 
-class (Foldable1 t, Traversable t) => Traversable1 t where
-  traverse1 :: Apply f => (a -> f b) -> t a -> f (t b)
-  sequence1 :: Apply f => t (f b) -> f (t b)
+class (NonEmptyFoldable t, Traversable t) => NonEmptyTraversable t where
+  traverseNE :: Semiapplicative f => (a -> f b) -> t a -> f (t b)
+  sequenceNE :: Semiapplicative f => t (f b) -> f (t b)
 
-  sequence1 = traverse1 id
-  traverse1 f = sequence1 . fmap f
+  sequenceNE = traverseNE id
+  traverseNE f = sequenceNE . fmap f
 
 #if __GLASGOW_HASKELL__ >= 708
-  {-# MINIMAL traverse1 | sequence1 #-}
+  {-# MINIMAL traverseNE | sequenceNE #-}
 #endif
 
-instance Traversable1 f => Traversable1 (Rec1 f) where
-  traverse1 f (Rec1 as) = Rec1 <$> traverse1 f as
+instance NonEmptyTraversable f => NonEmptyTraversable (Rec1 f) where
+  traverseNE f (Rec1 as) = Rec1 <$> traverseNE f as
 
-instance Traversable1 f => Traversable1 (M1 i c f) where
-  traverse1 f (M1 as) = M1 <$> traverse1 f as
+instance NonEmptyTraversable f => NonEmptyTraversable (M1 i c f) where
+  traverseNE f (M1 as) = M1 <$> traverseNE f as
 
-instance Traversable1 Par1 where
-  traverse1 f (Par1 a) = Par1 <$> f a
+instance NonEmptyTraversable Par1 where
+  traverseNE f (Par1 a) = Par1 <$> f a
 
-instance Traversable1 V1 where
-  traverse1 _ v = v `seq` undefined
+instance NonEmptyTraversable V1 where
+  traverseNE _ v = v `seq` undefined
 
-instance (Traversable1 f, Traversable1 g) => Traversable1 (f :*: g) where
-  traverse1 f (as :*: bs) = (:*:) <$> traverse1 f as <.> traverse1 f bs
+instance (NonEmptyTraversable f, NonEmptyTraversable g) => NonEmptyTraversable (f :*: g) where
+  traverseNE f (as :*: bs) = (:*:) <$> traverseNE f as <.> traverseNE f bs
 
-instance (Traversable1 f, Traversable1 g) => Traversable1 (f :+: g) where
-  traverse1 f (L1 as) = L1 <$> traverse1 f as
-  traverse1 f (R1 bs) = R1 <$> traverse1 f bs
+instance (NonEmptyTraversable f, NonEmptyTraversable g) => NonEmptyTraversable (f :+: g) where
+  traverseNE f (L1 as) = L1 <$> traverseNE f as
+  traverseNE f (R1 bs) = R1 <$> traverseNE f bs
 
-instance (Traversable1 f, Traversable1 g) => Traversable1 (f :.: g) where
-  traverse1 f (Comp1 m) = Comp1 <$> traverse1 (traverse1 f) m
+instance (NonEmptyTraversable f, NonEmptyTraversable g) => NonEmptyTraversable (f :.: g) where
+  traverseNE f (Comp1 m) = Comp1 <$> traverseNE (traverseNE f) m
 
-instance Traversable1 Identity where
-  traverse1 f = fmap Identity . f . runIdentity
+instance NonEmptyTraversable Identity where
+  traverseNE f = fmap Identity . f . runIdentity
 
-instance Traversable1 f => Traversable1 (IdentityT f) where
-  traverse1 f = fmap IdentityT . traverse1 f . runIdentityT
+instance NonEmptyTraversable f => NonEmptyTraversable (IdentityT f) where
+  traverseNE f = fmap IdentityT . traverseNE f . runIdentityT
 
-instance Traversable1 f => Traversable1 (Backwards f) where
-  traverse1 f = fmap Backwards . traverse1 f . forwards
+instance NonEmptyTraversable f => NonEmptyTraversable (Backwards f) where
+  traverseNE f = fmap Backwards . traverseNE f . forwards
 
-instance (Traversable1 f, Traversable1 g) => Traversable1 (Compose f g) where
-  traverse1 f = fmap Compose . traverse1 (traverse1 f) . getCompose
+instance (NonEmptyTraversable f, NonEmptyTraversable g) => NonEmptyTraversable (Compose f g) where
+  traverseNE f = fmap Compose . traverseNE (traverseNE f) . getCompose
 
-instance Traversable1 f => Traversable1 (Lift f) where
-  traverse1 f (Pure x)  = Pure <$> f x
-  traverse1 f (Other y) = Other <$> traverse1 f y
+instance NonEmptyTraversable f => NonEmptyTraversable (Lift f) where
+  traverseNE f (Pure x)  = Pure <$> f x
+  traverseNE f (Other y) = Other <$> traverseNE f y
 
-instance (Traversable1 f, Traversable1 g) => Traversable1 (Functor.Product f g) where
-  traverse1 f (Functor.Pair a b) = Functor.Pair <$> traverse1 f a <.> traverse1 f b
+instance (NonEmptyTraversable f, NonEmptyTraversable g) => NonEmptyTraversable (Functor.Product f g) where
+  traverseNE f (Functor.Pair a b) = Functor.Pair <$> traverseNE f a <.> traverseNE f b
 
-instance Traversable1 f => Traversable1 (Reverse f) where
-  traverse1 f = fmap Reverse . forwards . traverse1 (Backwards . f) . getReverse
+instance NonEmptyTraversable f => NonEmptyTraversable (Reverse f) where
+  traverseNE f = fmap Reverse . forwards . traverseNE (Backwards . f) . getReverse
 
-instance (Traversable1 f, Traversable1 g) => Traversable1 (Functor.Sum f g) where
-  traverse1 f (Functor.InL x) = Functor.InL <$> traverse1 f x
-  traverse1 f (Functor.InR y) = Functor.InR <$> traverse1 f y
+instance (NonEmptyTraversable f, NonEmptyTraversable g) => NonEmptyTraversable (Functor.Sum f g) where
+  traverseNE f (Functor.InL x) = Functor.InL <$> traverseNE f x
+  traverseNE f (Functor.InR y) = Functor.InR <$> traverseNE f y
 
 #if MIN_VERSION_base(4,4,0)
-instance Traversable1 Complex where
-  traverse1 f (a :+ b) = (:+) <$> f a <.> f b
-  {-# INLINE traverse1 #-}
+instance NonEmptyTraversable Complex where
+  traverseNE f (a :+ b) = (:+) <$> f a <.> f b
+  {-# INLINE traverseNE #-}
 #endif
 
 #ifdef MIN_VERSION_tagged
-instance Traversable1 (Tagged a) where
-  traverse1 f (Tagged a) = Tagged <$> f a
+instance NonEmptyTraversable (Tagged a) where
+  traverseNE f (Tagged a) = Tagged <$> f a
 #endif
 
 #ifdef MIN_VERSION_containers
-instance Traversable1 Tree where
-  traverse1 f (Node a []) = (`Node`[]) <$> f a
-  traverse1 f (Node a (x:xs)) = (\b (y:|ys) -> Node b (y:ys)) <$> f a <.> traverse1 (traverse1 f) (x :| xs)
+instance NonEmptyTraversable Tree where
+  traverseNE f (Node a []) = (`Node`[]) <$> f a
+  traverseNE f (Node a (x:xs)) = (\b (y:|ys) -> Node b (y:ys)) <$> f a <.> traverseNE (traverseNE f) (x :| xs)
 #endif
 
-instance Traversable1 NonEmpty where
-  traverse1 f (a :| []) = (:|[]) <$> f a
-  traverse1 f (a :| (b: bs)) = (\a' (b':| bs') -> a' :| b': bs') <$> f a <.> traverse1 f (b :| bs)
+instance NonEmptyTraversable NonEmpty where
+  traverseNE f (a :| []) = (:|[]) <$> f a
+  traverseNE f (a :| (b: bs)) = (\a' (b':| bs') -> a' :| b': bs') <$> f a <.> traverseNE f (b :| bs)
 
-instance Traversable1 ((,) a) where
-  traverse1 f (a, b) = (,) a <$> f b
+instance NonEmptyTraversable ((,) a) where
+  traverseNE f (a, b) = (,) a <$> f b
 
-instance Traversable1 g => Traversable1 (Joker g a) where
-  traverse1 g = fmap Joker . traverse1 g . runJoker
-  {-# INLINE traverse1 #-}
+instance NonEmptyTraversable g => NonEmptyTraversable (Joker g a) where
+  traverseNE g = fmap Joker . traverseNE g . runJoker
+  {-# INLINE traverseNE #-}
 
-instance Traversable1 Monoid.Sum where
-  traverse1 g (Monoid.Sum a) = Monoid.Sum <$> g a
+instance NonEmptyTraversable Monoid.Sum where
+  traverseNE g (Monoid.Sum a) = Monoid.Sum <$> g a
 
-instance Traversable1 Monoid.Product where
-  traverse1 g (Monoid.Product a) = Monoid.Product <$> g a
+instance NonEmptyTraversable Monoid.Product where
+  traverseNE g (Monoid.Product a) = Monoid.Product <$> g a
 
-instance Traversable1 Monoid.Dual where
-  traverse1 g (Monoid.Dual a) = Monoid.Dual <$> g a
+instance NonEmptyTraversable Monoid.Dual where
+  traverseNE g (Monoid.Dual a) = Monoid.Dual <$> g a
 
 #if MIN_VERSION_base(4,8,0)
-instance Traversable1 f => Traversable1 (Monoid.Alt f) where
-  traverse1 g (Monoid.Alt m) = Monoid.Alt <$> traverse1 g m
+instance NonEmptyTraversable f => NonEmptyTraversable (Monoid.Alt f) where
+  traverseNE g (Monoid.Alt m) = Monoid.Alt <$> traverseNE g m
 #endif
 
-instance Traversable1 Semigroup.First where
-  traverse1 g (Semigroup.First a) = Semigroup.First <$> g a
+instance NonEmptyTraversable Semigroup.First where
+  traverseNE g (Semigroup.First a) = Semigroup.First <$> g a
 
-instance Traversable1 Semigroup.Last where
-  traverse1 g (Semigroup.Last a) = Semigroup.Last <$> g a
+instance NonEmptyTraversable Semigroup.Last where
+  traverseNE g (Semigroup.Last a) = Semigroup.Last <$> g a
 
-instance Traversable1 Semigroup.Min where
-  traverse1 g (Semigroup.Min a) = Semigroup.Min <$> g a
+instance NonEmptyTraversable Semigroup.Min where
+  traverseNE g (Semigroup.Min a) = Semigroup.Min <$> g a
 
-instance Traversable1 Semigroup.Max where
-  traverse1 g (Semigroup.Max a) = Semigroup.Max <$> g a
+instance NonEmptyTraversable Semigroup.Max where
+  traverseNE g (Semigroup.Max a) = Semigroup.Max <$> g a

--- a/src/Data/Semigroupoid.hs
+++ b/src/Data/Semigroupoid.hs
@@ -30,7 +30,7 @@ module Data.Semigroupoid
 
 import Control.Applicative
 import Control.Arrow
-import Data.Functor.Bind
+import Data.Functor.Semimonad
 import Data.Semigroup
 import Control.Category
 import Prelude hiding (id, (.))
@@ -64,7 +64,7 @@ instance Semigroupoid (->) where
 instance Semigroupoid (,) where
   o (_,k) (i,_) = (i,k)
 
-instance Bind m => Semigroupoid (Kleisli m) where
+instance Semimonad m => Semigroupoid (Kleisli m) where
   Kleisli g `o` Kleisli f = Kleisli $ \a -> f a >>- g
 
 #ifdef MIN_VERSION_comonad

--- a/src/Data/Semigroupoid/Ob.hs
+++ b/src/Data/Semigroupoid/Ob.hs
@@ -18,7 +18,7 @@
 module Data.Semigroupoid.Ob where
 
 import Data.Semigroupoid
-import Data.Functor.Bind
+import Data.Functor.Semimonad
 import Control.Arrow
 
 
@@ -30,7 +30,7 @@ import Control.Comonad
 class Semigroupoid k => Ob k a where
   semiid :: k a a
 
-instance (Bind m, Monad m) => Ob (Kleisli m) a where
+instance (Semimonad m, Monad m) => Ob (Kleisli m) a where
   semiid = Kleisli return
 
 #ifdef MIN_VERSION_comonad

--- a/src/Data/Semigroupoid/Static.hs
+++ b/src/Data/Semigroupoid/Static.hs
@@ -23,7 +23,7 @@ import Control.Arrow
 import Control.Applicative
 import Control.Category
 import Control.Monad (ap)
-import Data.Functor.Apply
+import Data.Functor.Semiapplicative
 import Data.Functor.Plus
 import Data.Functor.Extend
 import Data.Orphans ()
@@ -47,10 +47,10 @@ newtype Static f a b = Static { runStatic :: f (a -> b) }
 instance Functor f => Functor (Static f a) where
   fmap f = Static . fmap (f .) . runStatic
 
-instance Apply f => Apply (Static f a) where
+instance Semiapplicative f => Semiapplicative (Static f a) where
   Static f <.> Static g = Static (ap <$> f <.> g)
 
-instance Alt f => Alt (Static f a) where
+instance Semialternative f => Semialternative (Static f a) where
   Static f <!> Static g = Static (f <!> g)
 
 instance Plus f => Plus (Static f a) where
@@ -69,7 +69,7 @@ instance (Comonad f, Monoid a) => Comonad (Static f a) where
   extract (Static g) = extract g mempty
 #endif
 
-instance Apply f => Semigroupoid (Static f) where
+instance Semiapplicative f => Semigroupoid (Static f) where
   Static f `o` Static g = Static ((.) <$> f <.> g)
 
 instance Applicative f => Category (Static f) where


### PR DESCRIPTION
Today I submitted [Foldable1 to base](https://mail.haskell.org/pipermail/libraries/2019-November/030059.html) proposal to CLC.

This is concrete patch to address #26 - bikeshed all the things issue.

- Apply -> Semiapplicative
- Bind -> Semimonad
- Foldable1 -> NonEmptyFoldable
- Traversable1 -> NonEmptyTraversable
- foldMap1 -> foldMapNE
- traverse1 -> traverseNE

Bi* classes are tricky, i went with

- Bifoldable1 -> NonEmptyBifoldable
- Bitraversable1 -> NonEmptyBitraversable
- Biapply -> Bisemiapplicative

This naming variant is the 3rd option in *Foldable1 to base* proposal, and I like these naming. I also extended it to cover other classes in this package.

You can look at haddocks at https://oleg.fi/haddocks/semigroupoids/ if it makes get the feel easier.

They make sense this way for me, i'm not sure if there're any prior art to these.

ping @andrewthad, @recursion-ninja, @chessai who commented on #26