### PR TITLE
No whitespace after the '@' in as-patterns

### DIFF
--- a/src/Data/Functor/Extend.hs
+++ b/src/Data/Functor/Extend.hs
@@ -164,7 +164,8 @@ instance Extend w => Extend (IdentityT w) where
   extended f (IdentityT m) = IdentityT (extended (f . IdentityT) m)
 
 instance Extend NonEmpty where
-  extended f w@ ~(_ :| aas) = f w :| case aas of
+  extended f w@(~(_ :| aas)) =
+    f w :| case aas of
       []     -> []
       (a:as) -> toList (extended f (a :| as))
 


### PR DESCRIPTION
Forward-compatibility for [GHC Proposal 229](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst)