### PR TITLE
Add instances for CPS transformers.

### DIFF
--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -40,6 +40,10 @@ import Control.Monad.Trans.Except
 import Control.Monad.Trans.List
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
+#if MIN_VERSION_transformers(0,5,6)
+import qualified Control.Monad.Trans.RWS.CPS as CPS
+import qualified Control.Monad.Trans.Writer.CPS as CPS
+#endif
 import qualified Control.Monad.Trans.RWS.Strict as Strict
 import qualified Control.Monad.Trans.State.Strict as Strict
 import qualified Control.Monad.Trans.Writer.Strict as Strict
@@ -260,11 +264,21 @@ instance Alt f => Alt (Strict.WriterT w f) where
 instance Alt f => Alt (Lazy.WriterT w f) where
   Lazy.WriterT m <!> Lazy.WriterT n = Lazy.WriterT $ m <!> n
 
+#if MIN_VERSION_transformers(0,5,6)
+instance (Alt f, Monoid.Monoid w) => Alt (CPS.WriterT w f) where
+  m <!> n = CPS.writerT $ CPS.runWriterT m <!> CPS.runWriterT n
+#endif
+
 instance Alt f => Alt (Strict.RWST r w s f) where
   Strict.RWST m <!> Strict.RWST n = Strict.RWST $ \r s -> m r s <!> n r s
 
 instance Alt f => Alt (Lazy.RWST r w s f) where
   Lazy.RWST m <!> Lazy.RWST n = Lazy.RWST $ \r s -> m r s <!> n r s
+
+#if MIN_VERSION_transformers(0,5,6)
+instance (Alt f, Monoid.Monoid w) => Alt (CPS.RWST r w s f) where
+  m <!> n = CPS.rwsT $ \r s -> CPS.runRWST m r s <!> CPS.runRWST n r s
+#endif
 
 instance Alt f => Alt (Backwards f) where
   Backwards a <!> Backwards b = Backwards (a <!> b)

--- a/src/Data/Functor/Bind/Trans.hs
+++ b/src/Data/Functor/Bind/Trans.hs
@@ -23,6 +23,10 @@ import Control.Monad.Trans.Identity
 -- import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
 -- import Control.Monad.Trans.List
+#if MIN_VERSION_transformers(0,5,6)
+import qualified Control.Monad.Trans.RWS.CPS as CPS
+import qualified Control.Monad.Trans.Writer.CPS as CPS
+#endif
 import qualified Control.Monad.Trans.RWS.Lazy as Lazy
 import qualified Control.Monad.Trans.State.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
@@ -52,6 +56,11 @@ instance Monoid w => BindTrans (Lazy.WriterT w) where
 instance Monoid w => BindTrans (Strict.WriterT w) where
   liftB = Strict.WriterT . fmap (\a -> (a, mempty))
 
+#if MIN_VERSION_transformers(0,5,6)
+instance Monoid w => BindTrans (CPS.WriterT w) where
+  liftB = CPS.writerT . fmap (\a -> (a, mempty))
+#endif
+
 instance BindTrans (Lazy.StateT s) where
   liftB m = Lazy.StateT $ \s -> fmap (\a -> (a, s)) m
 
@@ -63,6 +72,11 @@ instance Monoid w => BindTrans (Lazy.RWST r w s) where
 
 instance Monoid w => BindTrans (Strict.RWST r w s) where
   liftB m = Strict.RWST $ \ _r s -> fmap (\a -> (a, s, mempty)) m
+
+#if MIN_VERSION_transformers(0,5,6)
+instance Monoid w => BindTrans (CPS.RWST r w s) where
+  liftB m = CPS.rwsT $ \ _r s -> fmap (\a -> (a, s, mempty)) m
+#endif
 
 instance BindTrans (ContT r) where
   liftB m = ContT (m >>-)

--- a/src/Data/Functor/Plus.hs
+++ b/src/Data/Functor/Plus.hs
@@ -32,6 +32,10 @@ import Control.Monad.Trans.Except
 import Control.Monad.Trans.List
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
+#if MIN_VERSION_transformers(0,5,6)
+import qualified Control.Monad.Trans.RWS.CPS as CPS
+import qualified Control.Monad.Trans.Writer.CPS as CPS
+#endif
 import qualified Control.Monad.Trans.RWS.Strict as Strict
 import qualified Control.Monad.Trans.State.Strict as Strict
 import qualified Control.Monad.Trans.Writer.Strict as Strict
@@ -164,11 +168,21 @@ instance Plus f => Plus (Strict.WriterT w f) where
 instance Plus f => Plus (Lazy.WriterT w f) where
   zero = Lazy.WriterT zero
 
+#if MIN_VERSION_transformers(0,5,6)
+instance (Plus f, Monoid w) => Plus (CPS.WriterT w f) where
+  zero = CPS.writerT zero
+#endif
+
 instance Plus f => Plus (Strict.RWST r w s f) where
   zero = Strict.RWST $ \_ _ -> zero
 
 instance Plus f => Plus (Lazy.RWST r w s f) where
   zero = Lazy.RWST $ \_ _ -> zero
+
+#if MIN_VERSION_transformers(0,5,6)
+instance (Plus f, Monoid w) => Plus (CPS.RWST r w s f) where
+  zero = CPS.rwsT $ \_ _ -> zero
+#endif
 
 instance Plus f => Plus (Backwards f) where
   zero = Backwards zero


### PR DESCRIPTION
Conditionalized on transformers >= 0.5.6.

Unfortunately, the operations on CPS transformers are a bit
overconstrained (e.g., Monoid instead of Semigroup), so the instances are
correspondingly more constrained than the Lazy and Strict ones.