### PR TITLE
Add helpers for defining Traversable1 instances

### DIFF
--- a/src/Data/Functor/Apply.hs
+++ b/src/Data/Functor/Apply.hs
@@ -28,6 +28,8 @@ module Data.Functor.Apply (
   -- * Wrappers
   , WrappedApplicative(..)
   , MaybeApply(..)
+  , (<.*>)
+  , (<*.>)
   ) where
 
 import Data.Functor

--- a/src/Data/Semigroup/Traversable.hs
+++ b/src/Data/Semigroup/Traversable.hs
@@ -16,6 +16,10 @@
 ----------------------------------------------------------------------------
 module Data.Semigroup.Traversable
   ( Traversable1(..)
+  -- * Defining Traversable1 instances
+  -- $traversable1instances
+  , traverse1Maybe
+  -- * Default superclass instance helpers
   , foldMap1Default
   ) where
 
@@ -24,6 +28,20 @@ import Control.Applicative
 import Data.Semigroup
 #endif
 import Data.Semigroup.Traversable.Class
+import Data.Functor.Bind.Class
 
+-- | Default implementation of 'foldMap1' given an implementation of 'Traversable1'.
 foldMap1Default :: (Traversable1 f, Semigroup m) => (a -> m) -> f a -> m
 foldMap1Default f = getConst . traverse1 (Const . f)
+
+-- $traversable1instances
+-- Defining 'Traversable1' instances for types with both 'Traversable1' and 'Traversable' 
+-- substructures can be done with 'traverse1Maybe', '(<*.>)', and '(<.*>)'.
+--
+-- > data Foo a = Foo (Maybe a) (Maybe a) a [a]
+-- >   deriving (Functor, Traversable, Foldable)
+-- > instance Traversable1 Foo where
+-- >   traverse1 f (Foo ma ma' a as) = Foo <$> traverseMaybe ma <*> traverseMaybe ma' <*.> f a <.*> traverseMaybe as
+-- > instance Foldable1 Foo where
+-- >   foldMap1 = foldMap1Default
+


### PR DESCRIPTION
I was struggling to define such instances (in fact, I was trying to
write a `Traversal1` from `lens`, but it's the same problem), until I
found this [helpful
issue](https://github.com/ekmett/semigroupoids/issues/66) that shows how
to combine `Traversable` and `Traversable1` sub-structures using
`MaybeApply`.

I think this is very helpful for users, so I've added the functions from
the issue, another missing function, which I've called
`traverse1Maybe`, and a simple example so users can see how to put them
together.

Fixes #66.