### PR TITLE
Contravariant analogues of Apply/Alt/Plus (with revisions)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,7 @@
 ----------------
 * Remove instances for `Option`, which was removed in `base-4.16`.
 * Add `Alt` instance for `Identity`.
+* Add `Conclude`, `Decide` and `Divise` type classes and instances.
 
 5.3.5 [2020.12.31]
 ------------------

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -57,12 +57,14 @@ description:
   >
   .
   Then, for the \'contravariant hierarchy\':
+  .
   > Divise <--- Contravariant ---> Decide
   >    |                              |
   >    v                              v
   > Divisible ---> Decidable  <--- Conclude
   .
   Lastly, for the \'profunctor hierarchy\':
+  .
   > Semigroupoid
   >       |
   >       v

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -44,16 +44,32 @@ description:
   .
   Similarly many structures are nearly a comonad, but not quite, for instance lists provide a reasonable 'extend' operation in the form of 'tails', but do not always contain a value.
   .
-  Ideally the following relationships would hold:
+  Ideally the following relationships would hold. Firstly, for the \'covariant
+  hierarchy\':
   .
-  > Foldable ----> Traversable <--- Functor ------> Alt ---------> Plus           Semigroupoid
-  >      |               |            |                              |                  |
-  >      v               v            v                              v                  v
-  > Foldable1 ---> Traversable1     Apply --------> Applicative -> Alternative      Category
-  >                                   |               |              |                  |
-  >                                   v               v              v                  v
-  >                                 Bind ---------> Monad -------> MonadPlus          Arrow
+  > Foldable ----> Traversable <--- Functor ------> Alt ---------> Plus
+  >      |               |            |                              |
+  >      v               v            v                              v
+  > Foldable1 ---> Traversable1     Apply --------> Applicative -> Alternative
+  >                                   |               |              |
+  >                                   v               v              v
+  >                                 Bind ---------> Monad -------> MonadPlus
   >
+  .
+  Then, for the \'contravariant hierarchy\':
+  > Divise <--- Contravariant ---> Decide
+  >    |                              |
+  >    v                              v
+  > Divisible ---> Decidable  <--- Conclude
+  .
+  Lastly, for the \'profunctor hierarchy\':
+  > Semigroupoid
+  >       |
+  >       v
+  >   Category
+  >       |
+  >       v
+  >     Arrow
   .
   Apply, Bind, and Extend (not shown) give rise the Static, Kleisli and Cokleisli semigroupoids respectively.
   .

--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -188,7 +188,7 @@ instance Alt IO where
 -- | Choose the first option every time. While \'choose the last option\' every
 -- time is also valid, this instance satisfies more laws.
 --
--- /Since: 5.4/
+-- @since 5.4
 instance Alt Identity where
   {-# INLINEABLE (<!>) #-}
   m <!> _ = m

--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -188,7 +188,7 @@ instance Alt IO where
 -- | Choose the first option every time. While \'choose the last option\' every
 -- time is also valid, this instance satisfies more laws.
 --
--- @since 5.4
+-- /Since: 5.4/
 instance Alt Identity where
   {-# INLINEABLE (<!>) #-}
   m <!> _ = m

--- a/src/Data/Functor/Contravariant/Conclude.hs
+++ b/src/Data/Functor/Contravariant/Conclude.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE CPP           #-}
-{-# LANGUAGE Safe          #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 {-# LANGUAGE TypeOperators #-}
 
 -----------------------------------------------------------------------------

--- a/src/Data/Functor/Contravariant/Conclude.hs
+++ b/src/Data/Functor/Contravariant/Conclude.hs
@@ -92,7 +92,7 @@ import GHC.Generics
 -- 'Decide', it adds a way to construct an \"identity\" @conclude@ where
 -- @decide f x (conclude q) == x@, and @decide g (conclude r) y == y@.
 --
--- /Since: 5.4/
+-- @since 5.4
 class Decide f => Conclude f where
     -- | The consumer that cannot ever receive /any/ input.
     conclude :: (a -> Void) -> f a
@@ -105,117 +105,117 @@ class Decide f => Conclude f where
 -- 'concluded' = 'conclude' 'id'
 -- @
 --
--- /Since: 5.4/
+-- @since 5.4
 concluded :: Conclude f => f Void
 concluded = conclude id
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decidable f => Conclude (WrappedDivisible f) where
     conclude f = WrapDivisible (lose f)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude Comparison where conclude = lose
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude Equivalence where conclude = lose
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude Predicate where conclude = lose
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude (Op r) where
   conclude f = Op $ absurd . f
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude Proxy where conclude = lose
 #endif
 
 #ifdef MIN_VERSION_StateVar
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude SettableStateVar where conclude = lose
 #endif
 
 #if MIN_VERSION_base(4,8,0)
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude f => Conclude (Alt f) where
   conclude = Alt . conclude
 #endif
 
 #ifdef GHC_GENERICS
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude U1 where conclude = lose
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude f => Conclude (Rec1 f) where
   conclude = Rec1 . conclude
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude f => Conclude (M1 i c f) where
   conclude = M1 . conclude
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance (Conclude f, Conclude g) => Conclude (f :*: g) where
   conclude f = conclude f :*: conclude f
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance (Apply f, Applicative f, Conclude g) => Conclude (f :.: g) where
   conclude = Comp1 . pure . conclude
 #endif
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude f => Conclude (Backwards f) where
   conclude = Backwards . conclude
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude f => Conclude (IdentityT f) where
   conclude = IdentityT . conclude
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude m => Conclude (ReaderT r m) where
   conclude f = ReaderT $ \_ -> conclude f
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude m => Conclude (Lazy.RWST r w s m) where
   conclude f = Lazy.RWST $ \_ _ -> contramap (\ ~(a, _, _) -> a) (conclude f)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude m => Conclude (Strict.RWST r w s m) where
   conclude f = Strict.RWST $ \_ _ -> contramap (\(a, _, _) -> a) (conclude f)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance (Divisible m, Divise m) => Conclude (ListT m) where
   conclude _ = ListT conquer
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance (Divisible m, Divise m) => Conclude (MaybeT m) where
   conclude _ = MaybeT conquer
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude m => Conclude (Lazy.StateT s m) where
   conclude f = Lazy.StateT $ \_ -> contramap lazyFst (conclude f)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude m => Conclude (Strict.StateT s m) where
   conclude f = Strict.StateT $ \_ -> contramap fst (conclude f)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude m => Conclude (Lazy.WriterT w m) where
   conclude f = Lazy.WriterT $ contramap lazyFst (conclude f)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude m => Conclude (Strict.WriterT w m) where
   conclude f = Strict.WriterT $ contramap fst (conclude f)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance (Apply f, Applicative f, Conclude g) => Conclude (Compose f g) where
   conclude = Compose . pure . conclude
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance (Conclude f, Conclude g) => Conclude (Product f g) where
   conclude f = Pair (conclude f) (conclude f)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Conclude f => Conclude (Reverse f) where
   conclude = Reverse . conclude
 

--- a/src/Data/Functor/Contravariant/Conclude.hs
+++ b/src/Data/Functor/Contravariant/Conclude.hs
@@ -92,7 +92,7 @@ import GHC.Generics
 -- 'Decide', it adds a way to construct an \"identity\" @conclude@ where
 -- @decide f x (conclude q) == x@, and @decide g (conclude r) y == y@.
 --
--- @since 5.4
+-- /Since: 5.4/
 class Decide f => Conclude f where
     -- | The consumer that cannot ever receive /any/ input.
     conclude :: (a -> Void) -> f a
@@ -105,117 +105,117 @@ class Decide f => Conclude f where
 -- 'concluded' = 'conclude' 'id'
 -- @
 --
--- @since 5.4
+-- /Since: 5.4/
 concluded :: Conclude f => f Void
 concluded = conclude id
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decidable f => Conclude (WrappedDivisible f) where
     conclude f = WrapDivisible (lose f)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude Comparison where conclude = lose
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude Equivalence where conclude = lose
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude Predicate where conclude = lose
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude (Op r) where
   conclude f = Op $ absurd . f
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude Proxy where conclude = lose
 #endif
 
 #ifdef MIN_VERSION_StateVar
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude SettableStateVar where conclude = lose
 #endif
 
 #if MIN_VERSION_base(4,8,0)
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude f => Conclude (Alt f) where
   conclude = Alt . conclude
 #endif
 
 #ifdef GHC_GENERICS
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude U1 where conclude = lose
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude f => Conclude (Rec1 f) where
   conclude = Rec1 . conclude
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude f => Conclude (M1 i c f) where
   conclude = M1 . conclude
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance (Conclude f, Conclude g) => Conclude (f :*: g) where
   conclude f = conclude f :*: conclude f
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance (Apply f, Applicative f, Conclude g) => Conclude (f :.: g) where
   conclude = Comp1 . pure . conclude
 #endif
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude f => Conclude (Backwards f) where
   conclude = Backwards . conclude
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude f => Conclude (IdentityT f) where
   conclude = IdentityT . conclude
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude m => Conclude (ReaderT r m) where
   conclude f = ReaderT $ \_ -> conclude f
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude m => Conclude (Lazy.RWST r w s m) where
   conclude f = Lazy.RWST $ \_ _ -> contramap (\ ~(a, _, _) -> a) (conclude f)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude m => Conclude (Strict.RWST r w s m) where
   conclude f = Strict.RWST $ \_ _ -> contramap (\(a, _, _) -> a) (conclude f)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance (Divisible m, Divise m) => Conclude (ListT m) where
   conclude _ = ListT conquer
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance (Divisible m, Divise m) => Conclude (MaybeT m) where
   conclude _ = MaybeT conquer
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude m => Conclude (Lazy.StateT s m) where
   conclude f = Lazy.StateT $ \_ -> contramap lazyFst (conclude f)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude m => Conclude (Strict.StateT s m) where
   conclude f = Strict.StateT $ \_ -> contramap fst (conclude f)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude m => Conclude (Lazy.WriterT w m) where
   conclude f = Lazy.WriterT $ contramap lazyFst (conclude f)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude m => Conclude (Strict.WriterT w m) where
   conclude f = Strict.WriterT $ contramap fst (conclude f)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance (Apply f, Applicative f, Conclude g) => Conclude (Compose f g) where
   conclude = Compose . pure . conclude
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance (Conclude f, Conclude g) => Conclude (Product f g) where
   conclude f = Pair (conclude f) (conclude f)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Conclude f => Conclude (Reverse f) where
   conclude = Reverse . conclude
 

--- a/src/Data/Functor/Contravariant/Decide.hs
+++ b/src/Data/Functor/Contravariant/Decide.hs
@@ -82,7 +82,7 @@ import GHC.Generics
 -- That is, it is possible to define a function @(f `EitherDay` f) a ->
 -- f a@ in a way that is associative.
 --
--- @since 5.4
+-- /Since: 5.4/
 class Contravariant f => Decide f where
     -- | Takes the \"decision\" method and the two potential consumers, and
     -- returns the wrapped/combined consumer.
@@ -91,80 +91,80 @@ class Contravariant f => Decide f where
 -- | For @'decided' x y@, the resulting @f ('Either' b c)@ will direct
 -- 'Left's to be consumed by @x@, and 'Right's to be consumed by y.
 --
--- @since 5.4
+-- /Since: 5.4/
 decided :: Decide f => f b -> f c -> f (Either b c)
 decided = decide id
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decidable f => Decide (WrappedDivisible f) where
     decide f (WrapDivisible x) (WrapDivisible y) = WrapDivisible (choose f x y)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide Comparison where decide = choose
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide Equivalence where decide = choose
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide Predicate where decide = choose
 
 -- | Unlike 'Decidable', requires no constraint on @r@.
 --
--- @since 5.4
+-- /Since: 5.4/
 instance Decide (Op r) where
   decide f (Op g) (Op h) = Op $ either g h . f
 
 #if MIN_VERSION_base(4,8,0)
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide f => Decide (Alt f) where
   decide f (Alt l) (Alt r) = Alt $ decide f l r
 #endif
 
 #ifdef GHC_GENERICS
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide U1 where decide = choose
 
 -- | Has no 'Decidable' or 'Conclude' instance.
 --
--- @since 5.4
+-- /Since: 5.4/
 #if MIN_VERSION_base(4,7,0)
 instance Decide V1 where decide _ x = case x of {}
 #else
 instance Decide V1 where decide _ x = case x of !_ -> error "V1"
 #endif
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide f => Decide (Rec1 f) where
   decide f (Rec1 l) (Rec1 r) = Rec1 $ decide f l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide f => Decide (M1 i c f) where
   decide f (M1 l) (M1 r) = M1 $ decide f l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance (Decide f, Decide g) => Decide (f :*: g) where
   decide f (l1 :*: r1) (l2 :*: r2) = decide f l1 l2 :*: decide f r1 r2
 
 -- | Unlike 'Decidable', requires only 'Apply' on @f@.
 --
--- @since 5.4
+-- /Since: 5.4/
 instance (Apply f, Decide g) => Decide (f :.: g) where
   decide f (Comp1 l) (Comp1 r) = Comp1 (liftF2 (decide f) l r)
 #endif
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide f => Decide (Backwards f) where
   decide f (Backwards l) (Backwards r) = Backwards $ decide f l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide f => Decide (IdentityT f) where
   decide f (IdentityT l) (IdentityT r) = IdentityT $ decide f l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide m => Decide (ReaderT r m) where
   decide abc (ReaderT rmb) (ReaderT rmc) = ReaderT $ \r -> decide abc (rmb r) (rmc r)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide m => Decide (Lazy.RWST r w s m) where
   decide abc (Lazy.RWST rsmb) (Lazy.RWST rsmc) = Lazy.RWST $ \r s ->
     decide (\ ~(a, s', w) -> either (Left  . betuple3 s' w)
@@ -172,7 +172,7 @@ instance Decide m => Decide (Lazy.RWST r w s m) where
                                     (abc a))
            (rsmb r s) (rsmc r s)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide m => Decide (Strict.RWST r w s m) where
   decide abc (Strict.RWST rsmb) (Strict.RWST rsmc) = Strict.RWST $ \r s ->
     decide (\(a, s', w) -> either (Left  . betuple3 s' w)
@@ -180,11 +180,11 @@ instance Decide m => Decide (Strict.RWST r w s m) where
                                   (abc a))
            (rsmb r s) (rsmc r s)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Decide (ListT m) where
   decide f (ListT l) (ListT r) = ListT $ divise ((lefts &&& rights) . map f) l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Decide (MaybeT m) where
   decide f (MaybeT l) (MaybeT r) = MaybeT $
     divise ( maybe (Nothing, Nothing)
@@ -192,39 +192,39 @@ instance Divise m => Decide (MaybeT m) where
                            (\c -> (Nothing, Just c)) . f)
            ) l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide m => Decide (Lazy.StateT s m) where
   decide f (Lazy.StateT l) (Lazy.StateT r) = Lazy.StateT $ \s ->
     decide (\ ~(a, s') -> either (Left . betuple s') (Right . betuple s') (f a))
            (l s) (r s)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide m => Decide (Strict.StateT s m) where
   decide f (Strict.StateT l) (Strict.StateT r) = Strict.StateT $ \s ->
     decide (\(a, s') -> either (Left . betuple s') (Right . betuple s') (f a))
            (l s) (r s)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide m => Decide (Lazy.WriterT w m) where
   decide f (Lazy.WriterT l) (Lazy.WriterT r) = Lazy.WriterT $
     decide (\ ~(a, s') -> either (Left . betuple s') (Right . betuple s') (f a)) l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide m => Decide (Strict.WriterT w m) where
   decide f (Strict.WriterT l) (Strict.WriterT r) = Strict.WriterT $
     decide (\(a, s') -> either (Left . betuple s') (Right . betuple s') (f a)) l r
 
 -- | Unlike 'Decidable', requires only 'Apply' on @f@.
 --
--- @since 5.4
+-- /Since: 5.4/
 instance (Apply f, Decide g) => Decide (Compose f g) where
   decide f (Compose l) (Compose r) = Compose (liftF2 (decide f) l r)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance (Decide f, Decide g) => Decide (Product f g) where
   decide f (Pair l1 r1) (Pair l2 r2) = Pair (decide f l1 l2) (decide f r1 r2)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide f => Decide (Reverse f) where
   decide f (Reverse l) (Reverse r) = Reverse $ decide f l r
 
@@ -235,13 +235,13 @@ betuple3 :: s -> w -> a -> (a, s, w)
 betuple3 s w a = (a, s, w)
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide Proxy where
   decide _ Proxy Proxy = Proxy
 #endif
 
 #ifdef MIN_VERSION_StateVar
--- | @since 5.4
+-- | /Since: 5.4/
 instance Decide SettableStateVar where
   decide k (SettableStateVar l) (SettableStateVar r) = SettableStateVar $ \ a -> case k a of
     Left b -> l b

--- a/src/Data/Functor/Contravariant/Decide.hs
+++ b/src/Data/Functor/Contravariant/Decide.hs
@@ -82,7 +82,7 @@ import GHC.Generics
 -- That is, it is possible to define a function @(f `EitherDay` f) a ->
 -- f a@ in a way that is associative.
 --
--- /Since: 5.4/
+-- @since 5.4
 class Contravariant f => Decide f where
     -- | Takes the \"decision\" method and the two potential consumers, and
     -- returns the wrapped/combined consumer.
@@ -91,80 +91,80 @@ class Contravariant f => Decide f where
 -- | For @'decided' x y@, the resulting @f ('Either' b c)@ will direct
 -- 'Left's to be consumed by @x@, and 'Right's to be consumed by y.
 --
--- /Since: 5.4/
+-- @since 5.4
 decided :: Decide f => f b -> f c -> f (Either b c)
 decided = decide id
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decidable f => Decide (WrappedDivisible f) where
     decide f (WrapDivisible x) (WrapDivisible y) = WrapDivisible (choose f x y)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide Comparison where decide = choose
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide Equivalence where decide = choose
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide Predicate where decide = choose
 
 -- | Unlike 'Decidable', requires no constraint on @r@.
 --
--- /Since: 5.4/
+-- @since 5.4
 instance Decide (Op r) where
   decide f (Op g) (Op h) = Op $ either g h . f
 
 #if MIN_VERSION_base(4,8,0)
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide f => Decide (Alt f) where
   decide f (Alt l) (Alt r) = Alt $ decide f l r
 #endif
 
 #ifdef GHC_GENERICS
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide U1 where decide = choose
 
 -- | Has no 'Decidable' or 'Conclude' instance.
 --
--- /Since: 5.4/
+-- @since 5.4
 #if MIN_VERSION_base(4,7,0)
 instance Decide V1 where decide _ x = case x of {}
 #else
 instance Decide V1 where decide _ x = case x of !_ -> error "V1"
 #endif
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide f => Decide (Rec1 f) where
   decide f (Rec1 l) (Rec1 r) = Rec1 $ decide f l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide f => Decide (M1 i c f) where
   decide f (M1 l) (M1 r) = M1 $ decide f l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance (Decide f, Decide g) => Decide (f :*: g) where
   decide f (l1 :*: r1) (l2 :*: r2) = decide f l1 l2 :*: decide f r1 r2
 
 -- | Unlike 'Decidable', requires only 'Apply' on @f@.
 --
--- /Since: 5.4/
+-- @since 5.4
 instance (Apply f, Decide g) => Decide (f :.: g) where
   decide f (Comp1 l) (Comp1 r) = Comp1 (liftF2 (decide f) l r)
 #endif
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide f => Decide (Backwards f) where
   decide f (Backwards l) (Backwards r) = Backwards $ decide f l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide f => Decide (IdentityT f) where
   decide f (IdentityT l) (IdentityT r) = IdentityT $ decide f l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide m => Decide (ReaderT r m) where
   decide abc (ReaderT rmb) (ReaderT rmc) = ReaderT $ \r -> decide abc (rmb r) (rmc r)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide m => Decide (Lazy.RWST r w s m) where
   decide abc (Lazy.RWST rsmb) (Lazy.RWST rsmc) = Lazy.RWST $ \r s ->
     decide (\ ~(a, s', w) -> either (Left  . betuple3 s' w)
@@ -172,7 +172,7 @@ instance Decide m => Decide (Lazy.RWST r w s m) where
                                     (abc a))
            (rsmb r s) (rsmc r s)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide m => Decide (Strict.RWST r w s m) where
   decide abc (Strict.RWST rsmb) (Strict.RWST rsmc) = Strict.RWST $ \r s ->
     decide (\(a, s', w) -> either (Left  . betuple3 s' w)
@@ -180,11 +180,11 @@ instance Decide m => Decide (Strict.RWST r w s m) where
                                   (abc a))
            (rsmb r s) (rsmc r s)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Decide (ListT m) where
   decide f (ListT l) (ListT r) = ListT $ divise ((lefts &&& rights) . map f) l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Decide (MaybeT m) where
   decide f (MaybeT l) (MaybeT r) = MaybeT $
     divise ( maybe (Nothing, Nothing)
@@ -192,39 +192,39 @@ instance Divise m => Decide (MaybeT m) where
                            (\c -> (Nothing, Just c)) . f)
            ) l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide m => Decide (Lazy.StateT s m) where
   decide f (Lazy.StateT l) (Lazy.StateT r) = Lazy.StateT $ \s ->
     decide (\ ~(a, s') -> either (Left . betuple s') (Right . betuple s') (f a))
            (l s) (r s)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide m => Decide (Strict.StateT s m) where
   decide f (Strict.StateT l) (Strict.StateT r) = Strict.StateT $ \s ->
     decide (\(a, s') -> either (Left . betuple s') (Right . betuple s') (f a))
            (l s) (r s)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide m => Decide (Lazy.WriterT w m) where
   decide f (Lazy.WriterT l) (Lazy.WriterT r) = Lazy.WriterT $
     decide (\ ~(a, s') -> either (Left . betuple s') (Right . betuple s') (f a)) l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide m => Decide (Strict.WriterT w m) where
   decide f (Strict.WriterT l) (Strict.WriterT r) = Strict.WriterT $
     decide (\(a, s') -> either (Left . betuple s') (Right . betuple s') (f a)) l r
 
 -- | Unlike 'Decidable', requires only 'Apply' on @f@.
 --
--- /Since: 5.4/
+-- @since 5.4
 instance (Apply f, Decide g) => Decide (Compose f g) where
   decide f (Compose l) (Compose r) = Compose (liftF2 (decide f) l r)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance (Decide f, Decide g) => Decide (Product f g) where
   decide f (Pair l1 r1) (Pair l2 r2) = Pair (decide f l1 l2) (decide f r1 r2)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide f => Decide (Reverse f) where
   decide f (Reverse l) (Reverse r) = Reverse $ decide f l r
 
@@ -235,13 +235,13 @@ betuple3 :: s -> w -> a -> (a, s, w)
 betuple3 s w a = (a, s, w)
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide Proxy where
   decide _ Proxy Proxy = Proxy
 #endif
 
 #ifdef MIN_VERSION_StateVar
--- | /Since: 5.4/
+-- | @since 5.4
 instance Decide SettableStateVar where
   decide k (SettableStateVar l) (SettableStateVar r) = SettableStateVar $ \ a -> case k a of
     Left b -> l b

--- a/src/Data/Functor/Contravariant/Decide.hs
+++ b/src/Data/Functor/Contravariant/Decide.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE BangPatterns  #-}
 {-# LANGUAGE CPP           #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE Safe          #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 #if MIN_VERSION_base(4,7,0)
 {-# LANGUAGE EmptyCase     #-}
 #endif

--- a/src/Data/Functor/Contravariant/Decide.hs
+++ b/src/Data/Functor/Contravariant/Decide.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE CPP           #-}
 {-# LANGUAGE TypeOperators #-}
-
+{-# LANGUAGE Safe          #-}
 #if MIN_VERSION_base(4,7,0)
 {-# LANGUAGE EmptyCase     #-}
 #endif
 
 -----------------------------------------------------------------------------
 -- |
--- Copyright   :  (C) 2011-2015 Edward Kmett
+-- Copyright   :  (C) 2021 Edward Kmett
 -- License     :  BSD-style (see the file LICENSE)
 --
 -- Maintainer  :  Edward Kmett <ekmett@gmail.com>
@@ -68,73 +68,98 @@ import GHC.Generics
 -- exactly one of two independent consumers.  It redirects the input
 -- completely into one of two consumers.
 --
--- 'decide' takes the "decision" method and the two potential consumers,
+-- 'decide' takes the \"decision\" method and the two potential consumers,
 -- and returns the wrapped/combined consumer.
 --
 -- Mathematically, a functor being an instance of 'Decide' means that it is
--- "semgroupoidal" with respect to the contravariant "either-based" Day
+-- \"semigroupoidal\" with respect to the contravariant \"either-based\" Day
 -- convolution (@data EitherDay f g a = forall b c. EitherDay (f b) (g c) (a -> Either b c)@).
 -- That is, it is possible to define a function @(f `EitherDay` f) a ->
 -- f a@ in a way that is associative.
+--
+-- @since 5.4
 class Contravariant f => Decide f where
-    -- | Takes the "decision" method and the two potential consumers, and
+    -- | Takes the \"decision\" method and the two potential consumers, and
     -- returns the wrapped/combined consumer.
     decide :: (a -> Either b c) -> f b -> f c -> f a
 
 -- | For @'decided' x y@, the resulting @f ('Either' b c)@ will direct
 -- 'Left's to be consumed by @x@, and 'Right's to be consumed by y.
+--
+-- @since 5.4
 decided :: Decide f => f b -> f c -> f (Either b c)
 decided = decide id
 
+-- | @since 5.4
 instance Decidable f => Decide (WrappedDivisible f) where
     decide f (WrapDivisible x) (WrapDivisible y) = WrapDivisible (choose f x y)
 
+-- | @since 5.4
 instance Decide Comparison where decide = choose
+
+-- | @since 5.4
 instance Decide Equivalence where decide = choose
+
+-- | @since 5.4
 instance Decide Predicate where decide = choose
 
--- | Unlike 'Decidable', requires no constraint on @r@
+-- | Unlike 'Decidable', requires no constraint on @r@.
+--
+-- @since 5.4
 instance Decide (Op r) where
   decide f (Op g) (Op h) = Op $ either g h . f
 
 #if MIN_VERSION_base(4,8,0)
+-- | @since 5.4
 instance Decide f => Decide (Alt f) where
   decide f (Alt l) (Alt r) = Alt $ decide f l r
 #endif
 
 #ifdef GHC_GENERICS
+-- | @since 5.4
 instance Decide U1 where decide = choose
 
--- | Has no 'Decidable' or 'Conclude' instance
+-- | Has no 'Decidable' or 'Conclude' instance.
+--
+-- @since 5.4
 #if MIN_VERSION_base(4,7,0)
 instance Decide V1 where decide _ x = case x of {}
 #else
-instance Decide V1 where decide _ x = case x of _ -> error "V1"
+instance Decide V1 where decide _ x = case x of !_ -> error "V1"
 #endif
 
+-- | @since 5.4
 instance Decide f => Decide (Rec1 f) where
   decide f (Rec1 l) (Rec1 r) = Rec1 $ decide f l r
 
+-- | @since 5.4
 instance Decide f => Decide (M1 i c f) where
   decide f (M1 l) (M1 r) = M1 $ decide f l r
 
+-- | @since 5.4
 instance (Decide f, Decide g) => Decide (f :*: g) where
   decide f (l1 :*: r1) (l2 :*: r2) = decide f l1 l2 :*: decide f r1 r2
 
 -- | Unlike 'Decidable', requires only 'Apply' on @f@.
+--
+-- @since 5.4
 instance (Apply f, Decide g) => Decide (f :.: g) where
   decide f (Comp1 l) (Comp1 r) = Comp1 (liftF2 (decide f) l r)
 #endif
 
+-- | @since 5.4
 instance Decide f => Decide (Backwards f) where
   decide f (Backwards l) (Backwards r) = Backwards $ decide f l r
 
+-- | @since 5.4
 instance Decide f => Decide (IdentityT f) where
   decide f (IdentityT l) (IdentityT r) = IdentityT $ decide f l r
 
+-- | @since 5.4
 instance Decide m => Decide (ReaderT r m) where
   decide abc (ReaderT rmb) (ReaderT rmc) = ReaderT $ \r -> decide abc (rmb r) (rmc r)
 
+-- | @since 5.4
 instance Decide m => Decide (Lazy.RWST r w s m) where
   decide abc (Lazy.RWST rsmb) (Lazy.RWST rsmc) = Lazy.RWST $ \r s ->
     decide (\ ~(a, s', w) -> either (Left  . betuple3 s' w)
@@ -142,6 +167,7 @@ instance Decide m => Decide (Lazy.RWST r w s m) where
                                     (abc a))
            (rsmb r s) (rsmc r s)
 
+-- | @since 5.4
 instance Decide m => Decide (Strict.RWST r w s m) where
   decide abc (Strict.RWST rsmb) (Strict.RWST rsmc) = Strict.RWST $ \r s ->
     decide (\(a, s', w) -> either (Left  . betuple3 s' w)
@@ -149,9 +175,11 @@ instance Decide m => Decide (Strict.RWST r w s m) where
                                   (abc a))
            (rsmb r s) (rsmc r s)
 
+-- | @since 5.4
 instance Divise m => Decide (ListT m) where
   decide f (ListT l) (ListT r) = ListT $ divise ((lefts &&& rights) . map f) l r
 
+-- | @since 5.4
 instance Divise m => Decide (MaybeT m) where
   decide f (MaybeT l) (MaybeT r) = MaybeT $
     divise ( maybe (Nothing, Nothing)
@@ -159,31 +187,39 @@ instance Divise m => Decide (MaybeT m) where
                            (\c -> (Nothing, Just c)) . f)
            ) l r
 
+-- | @since 5.4
 instance Decide m => Decide (Lazy.StateT s m) where
   decide f (Lazy.StateT l) (Lazy.StateT r) = Lazy.StateT $ \s ->
     decide (\ ~(a, s') -> either (Left . betuple s') (Right . betuple s') (f a))
            (l s) (r s)
 
+-- | @since 5.4
 instance Decide m => Decide (Strict.StateT s m) where
   decide f (Strict.StateT l) (Strict.StateT r) = Strict.StateT $ \s ->
     decide (\(a, s') -> either (Left . betuple s') (Right . betuple s') (f a))
            (l s) (r s)
 
+-- | @since 5.4
 instance Decide m => Decide (Lazy.WriterT w m) where
   decide f (Lazy.WriterT l) (Lazy.WriterT r) = Lazy.WriterT $
     decide (\ ~(a, s') -> either (Left . betuple s') (Right . betuple s') (f a)) l r
 
+-- | @since 5.4
 instance Decide m => Decide (Strict.WriterT w m) where
   decide f (Strict.WriterT l) (Strict.WriterT r) = Strict.WriterT $
     decide (\(a, s') -> either (Left . betuple s') (Right . betuple s') (f a)) l r
 
 -- | Unlike 'Decidable', requires only 'Apply' on @f@.
+--
+-- @since 5.4
 instance (Apply f, Decide g) => Decide (Compose f g) where
   decide f (Compose l) (Compose r) = Compose (liftF2 (decide f) l r)
 
+-- | @since 5.4
 instance (Decide f, Decide g) => Decide (Product f g) where
   decide f (Pair l1 r1) (Pair l2 r2) = Pair (decide f l1 l2) (decide f r1 r2)
 
+-- | @since 5.4
 instance Decide f => Decide (Reverse f) where
   decide f (Reverse l) (Reverse r) = Reverse $ decide f l r
 
@@ -194,11 +230,13 @@ betuple3 :: s -> w -> a -> (a, s, w)
 betuple3 s w a = (a, s, w)
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
+-- | @since 5.4
 instance Decide Proxy where
   decide _ Proxy Proxy = Proxy
 #endif
 
 #ifdef MIN_VERSION_StateVar
+-- | @since 5.4
 instance Decide SettableStateVar where
   decide k (SettableStateVar l) (SettableStateVar r) = SettableStateVar $ \ a -> case k a of
     Left b -> l b

--- a/src/Data/Functor/Contravariant/Decide.hs
+++ b/src/Data/Functor/Contravariant/Decide.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns  #-}
 {-# LANGUAGE CPP           #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE Safe          #-}

--- a/src/Data/Functor/Contravariant/Divise.hs
+++ b/src/Data/Functor/Contravariant/Divise.hs
@@ -97,7 +97,7 @@ import GHC.Generics
 -- convolution.  That is, it is possible to define a function @(f `Day` f)
 -- a -> f a@ in a way that is associative.
 --
--- /Since: 5.4/
+-- @since 5.4
 class Contravariant f => Divise f where
     -- | Takes a \"splitting\" method and the two sub-consumers, and
     -- returns the wrapped/combined consumer.
@@ -110,183 +110,183 @@ class Contravariant f => Divise f where
 -- 'divised' = 'divise' 'id'
 -- @
 --
--- /Since: 5.4/
+-- @since 5.4
 divised :: Divise f => f a -> f b -> f (a, b)
 divised = divise id
 
 -- | Wrap a 'Divisible' to be used as a member of 'Divise'
 --
--- /Since: 5.4/
+-- @since 5.4
 newtype WrappedDivisible f a = WrapDivisible { unwrapDivisible :: f a }
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Contravariant f => Contravariant (WrappedDivisible f) where
   contramap f (WrapDivisible a) = WrapDivisible (contramap f a)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divisible f => Divise (WrappedDivisible f) where
   divise f (WrapDivisible x) (WrapDivisible y) = WrapDivisible (divide f x y)
 
 #if MIN_VERSION_base(4,9,0)
 -- | Unlike 'Divisible', requires only 'Semigroup' on @r@.
 --
--- /Since: 5.4/
+-- @since 5.4
 instance Semigroup r => Divise (Op r) where
     divise f (Op g) (Op h) = Op $ \a -> case f a of
       (b, c) -> g b <> h c
 
 -- | Unlike 'Divisible', requires only 'Semigroup' on @m@.
 --
--- /Since: 5.4/
+-- @since 5.4
 instance Semigroup m => Divise (Const m) where
     divise _ (Const a) (Const b) = Const (a <> b)
 
 -- | Unlike 'Divisible', requires only 'Semigroup' on @m@.
 --
--- /Since: 5.4/
+-- @since 5.4
 instance Semigroup m => Divise (Constant m) where
     divise _ (Constant a) (Constant b) = Constant (a <> b)
 #else
--- | /Since: 5.4/
+-- | @since 5.4
 instance Monoid r => Divise (Op r) where divise = divide
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Monoid m => Divise (Const m) where divise = divide
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Monoid m => Divise (Constant m) where divise = divide
 #endif
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise Comparison where divise = divide
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise Equivalence where divise = divide
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise Predicate where divise = divide
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise Proxy where divise = divide
 #endif
 
 #ifdef MIN_VERSION_StateVar
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise SettableStateVar where divise = divide
 #endif
 
 #if MIN_VERSION_base(4,8,0)
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise f => Divise (Alt f) where
   divise f (Alt l) (Alt r) = Alt $ divise f l r
 #endif
 
 #ifdef GHC_GENERICS
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise U1 where divise = divide
 
 -- | Has no 'Divisible' instance.
 --
--- /Since: 5.4/
+-- @since 5.4
 #if MIN_VERSION_base(4,7,0)
 instance Divise V1 where divise _ x = case x of {}
 #else
 instance Divise V1 where divise _ !_ = error "V1"
 #endif
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise f => Divise (Rec1 f) where
   divise f (Rec1 l) (Rec1 r) = Rec1 $ divise f l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise f => Divise (M1 i c f) where
   divise f (M1 l) (M1 r) = M1 $ divise f l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance (Divise f, Divise g) => Divise (f :*: g) where
   divise f (l1 :*: r1) (l2 :*: r2) = divise f l1 l2 :*: divise f r1 r2
 
 -- | Unlike 'Divisible', requires only 'Apply' on @f@.
 --
--- /Since: 5.4/
+-- @since 5.4
 instance (Apply f, Divise g) => Divise (f :.: g) where
   divise f (Comp1 l) (Comp1 r) = Comp1 (liftF2 (divise f) l r)
 #endif
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise f => Divise (Backwards f) where
   divise f (Backwards l) (Backwards r) = Backwards $ divise f l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (ErrorT e m) where
   divise f (ErrorT l) (ErrorT r) = ErrorT $ divise (funzip . fmap f) l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (ExceptT e m) where
   divise f (ExceptT l) (ExceptT r) = ExceptT $ divise (funzip . fmap f) l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise f => Divise (IdentityT f) where
   divise f (IdentityT l) (IdentityT r) = IdentityT $ divise f l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (ListT m) where
   divise f (ListT l) (ListT r) = ListT $ divise (funzip . map f) l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (MaybeT m) where
   divise f (MaybeT l) (MaybeT r) = MaybeT $ divise (funzip . fmap f) l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (ReaderT r m) where
   divise abc (ReaderT rmb) (ReaderT rmc) = ReaderT $ \r -> divise abc (rmb r) (rmc r)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (Lazy.RWST r w s m) where
   divise abc (Lazy.RWST rsmb) (Lazy.RWST rsmc) = Lazy.RWST $ \r s ->
     divise (\ ~(a, s', w) -> case abc a of
                                   ~(b, c) -> ((b, s', w), (c, s', w)))
            (rsmb r s) (rsmc r s)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (Strict.RWST r w s m) where
   divise abc (Strict.RWST rsmb) (Strict.RWST rsmc) = Strict.RWST $ \r s ->
     divise (\(a, s', w) -> case abc a of
                                 (b, c) -> ((b, s', w), (c, s', w)))
            (rsmb r s) (rsmc r s)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (Lazy.StateT s m) where
   divise f (Lazy.StateT l) (Lazy.StateT r) = Lazy.StateT $ \s ->
     divise (lazyFanout f) (l s) (r s)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (Strict.StateT s m) where
   divise f (Strict.StateT l) (Strict.StateT r) = Strict.StateT $ \s ->
     divise (strictFanout f) (l s) (r s)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (Lazy.WriterT w m) where
   divise f (Lazy.WriterT l) (Lazy.WriterT r) = Lazy.WriterT $
     divise (lazyFanout f) l r
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise m => Divise (Strict.WriterT w m) where
   divise f (Strict.WriterT l) (Strict.WriterT r) = Strict.WriterT $
     divise (strictFanout f) l r
 
 -- | Unlike 'Divisible', requires only 'Apply' on @f@.
 --
--- /Since: 5.4/
+-- @since 5.4
 instance (Apply f, Divise g) => Divise (Compose f g) where
   divise f (Compose l) (Compose r) = Compose (liftF2 (divise f) l r)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance (Divise f, Divise g) => Divise (Product f g) where
   divise f (Pair l1 r1) (Pair l2 r2) = Pair (divise f l1 l2) (divise f r1 r2)
 
--- | /Since: 5.4/
+-- | @since 5.4
 instance Divise f => Divise (Reverse f) where
   divise f (Reverse l) (Reverse r) = Reverse $ divise f l r
 

--- a/src/Data/Functor/Contravariant/Divise.hs
+++ b/src/Data/Functor/Contravariant/Divise.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE CPP           #-}
 {-# LANGUAGE TypeOperators #-}
-
+{-# LANGUAGE Safe          #-}
 #if MIN_VERSION_base(4,7,0)
 {-# LANGUAGE EmptyCase     #-}
 #endif
 
 -----------------------------------------------------------------------------
 -- |
--- Copyright   :  (C) 2011-2015 Edward Kmett
+-- Copyright   :  (C) 2021 Edward Kmett
 -- License     :  BSD-style (see the file LICENSE)
 --
 -- Maintainer  :  Edward Kmett <ekmett@gmail.com>
@@ -75,23 +75,26 @@ import GHC.Generics
 -- to handle the consumption of a value by splitting it between two
 -- consumers that consume separate parts of @a@.
 --
--- 'divise' takes the "splitting" method and the two sub-consumers, and
+-- 'divise' takes the \"splitting\" method and the two sub-consumers, and
 -- returns the wrapped/combined consumer.
 --
 -- All instances of 'Divisible' should be instances of 'Divise' with
 -- @'divise' = 'divide'@.
---
--- The guarantee that a function polymorphic over of @'Divise' f@ provides
--- that @'Divisible' f@ doesn't that any input consumed will be passed to at
--- least one sub-consumer; it won't potentially disappear into the void, as
--- is possible if 'conquer' is available.
+-- 
+-- If a function is polymorphic over @'Divise' f@ (as opposed to @'Divisible'
+-- f@), we can provide a stronger guarantee: namely, that any input consumed
+-- will be passed to at least one sub-consumer. With @'Divisible' f@, said input
+-- could potentially disappear into the void, as this is possible with
+-- 'conquer'.
 --
 -- Mathematically, a functor being an instance of 'Divise' means that it is
--- "semgroupoidal" with respect to the contravariant (tupling) Day
+-- \"semigroupoidal\" with respect to the contravariant (tupling) Day
 -- convolution.  That is, it is possible to define a function @(f `Day` f)
 -- a -> f a@ in a way that is associative.
+--
+-- @since 5.4
 class Contravariant f => Divise f where
-    -- | Takes a "splitting" method and the two sub-consumers, and
+    -- | Takes a \"splitting\" method and the two sub-consumers, and
     -- returns the wrapped/combined consumer.
     divise :: (a -> (b, c)) -> f b -> f c -> f a
 
@@ -101,136 +104,188 @@ class Contravariant f => Divise f where
 -- @
 -- 'divised' = 'divise' 'id'
 -- @
+--
+-- @since 5.4
 divised :: Divise f => f a -> f b -> f (a, b)
 divised = divise id
 
 -- | Wrap a 'Divisible' to be used as a member of 'Divise'
+--
+-- @since 5.4
 newtype WrappedDivisible f a = WrapDivisible { unwrapDivisible :: f a }
 
+-- | @since 5.4
 instance Contravariant f => Contravariant (WrappedDivisible f) where
   contramap f (WrapDivisible a) = WrapDivisible (contramap f a)
 
+-- | @since 5.4
 instance Divisible f => Divise (WrappedDivisible f) where
   divise f (WrapDivisible x) (WrapDivisible y) = WrapDivisible (divide f x y)
 
 #if MIN_VERSION_base(4,9,0)
 -- | Unlike 'Divisible', requires only 'Semigroup' on @r@.
+--
+-- @since 5.4
 instance Semigroup r => Divise (Op r) where
     divise f (Op g) (Op h) = Op $ \a -> case f a of
       (b, c) -> g b <> h c
 
 -- | Unlike 'Divisible', requires only 'Semigroup' on @m@.
+--
+-- @since 5.4
 instance Semigroup m => Divise (Const m) where
     divise _ (Const a) (Const b) = Const (a <> b)
 
 -- | Unlike 'Divisible', requires only 'Semigroup' on @m@.
+--
+-- @since 5.4
 instance Semigroup m => Divise (Constant m) where
     divise _ (Constant a) (Constant b) = Constant (a <> b)
 #else
+-- | @since 5.4
 instance Monoid r => Divise (Op r) where divise = divide
+
+-- | @since 5.4
 instance Monoid m => Divise (Const m) where divise = divide
+
+-- | @since 5.4
 instance Monoid m => Divise (Constant m) where divise = divide
 #endif
 
+-- | @since 5.4
 instance Divise Comparison where divise = divide
+
+-- | @since 5.4
 instance Divise Equivalence where divise = divide
+
+-- | @since 5.4
 instance Divise Predicate where divise = divide
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
+-- | @since 5.4
 instance Divise Proxy where divise = divide
 #endif
 
 #ifdef MIN_VERSION_StateVar
+-- | @since 5.4
 instance Divise SettableStateVar where divise = divide
 #endif
 
 #if MIN_VERSION_base(4,8,0)
+-- | @since 5.4
 instance Divise f => Divise (Alt f) where
   divise f (Alt l) (Alt r) = Alt $ divise f l r
 #endif
 
 #ifdef GHC_GENERICS
+-- | @since 5.4
 instance Divise U1 where divise = divide
 
--- | Has no 'Divisible' instance
+-- | Has no 'Divisible' instance.
+--
+-- @since 5.4
 #if MIN_VERSION_base(4,7,0)
 instance Divise V1 where divise _ x = case x of {}
 #else
-instance Divise V1 where divise _ x = case x of _ -> error "V1"
+instance Divise V1 where divise _ !_ = error "V1"
 #endif
 
+-- | @since 5.4
 instance Divise f => Divise (Rec1 f) where
   divise f (Rec1 l) (Rec1 r) = Rec1 $ divise f l r
 
+-- | @since 5.4
 instance Divise f => Divise (M1 i c f) where
   divise f (M1 l) (M1 r) = M1 $ divise f l r
 
+-- | @since 5.4
 instance (Divise f, Divise g) => Divise (f :*: g) where
   divise f (l1 :*: r1) (l2 :*: r2) = divise f l1 l2 :*: divise f r1 r2
 
 -- | Unlike 'Divisible', requires only 'Apply' on @f@.
+--
+-- @since 5.4
 instance (Apply f, Divise g) => Divise (f :.: g) where
   divise f (Comp1 l) (Comp1 r) = Comp1 (liftF2 (divise f) l r)
 #endif
 
+-- | @since 5.4
 instance Divise f => Divise (Backwards f) where
   divise f (Backwards l) (Backwards r) = Backwards $ divise f l r
 
+-- | @since 5.4
 instance Divise m => Divise (ErrorT e m) where
   divise f (ErrorT l) (ErrorT r) = ErrorT $ divise (funzip . fmap f) l r
 
+-- | @since 5.4
 instance Divise m => Divise (ExceptT e m) where
   divise f (ExceptT l) (ExceptT r) = ExceptT $ divise (funzip . fmap f) l r
 
+-- | @since 5.4
 instance Divise f => Divise (IdentityT f) where
   divise f (IdentityT l) (IdentityT r) = IdentityT $ divise f l r
 
+-- | @since 5.4
 instance Divise m => Divise (ListT m) where
   divise f (ListT l) (ListT r) = ListT $ divise (funzip . map f) l r
 
+-- | @since 5.4
 instance Divise m => Divise (MaybeT m) where
   divise f (MaybeT l) (MaybeT r) = MaybeT $ divise (funzip . fmap f) l r
 
+-- | @since 5.4
 instance Divise m => Divise (ReaderT r m) where
   divise abc (ReaderT rmb) (ReaderT rmc) = ReaderT $ \r -> divise abc (rmb r) (rmc r)
 
+-- | @since 5.4
 instance Divise m => Divise (Lazy.RWST r w s m) where
   divise abc (Lazy.RWST rsmb) (Lazy.RWST rsmc) = Lazy.RWST $ \r s ->
     divise (\ ~(a, s', w) -> case abc a of
                                   ~(b, c) -> ((b, s', w), (c, s', w)))
            (rsmb r s) (rsmc r s)
 
+-- | @since 5.4
 instance Divise m => Divise (Strict.RWST r w s m) where
   divise abc (Strict.RWST rsmb) (Strict.RWST rsmc) = Strict.RWST $ \r s ->
     divise (\(a, s', w) -> case abc a of
                                 (b, c) -> ((b, s', w), (c, s', w)))
            (rsmb r s) (rsmc r s)
 
+-- | @since 5.4
 instance Divise m => Divise (Lazy.StateT s m) where
   divise f (Lazy.StateT l) (Lazy.StateT r) = Lazy.StateT $ \s ->
     divise (lazyFanout f) (l s) (r s)
 
+-- | @since 5.4
 instance Divise m => Divise (Strict.StateT s m) where
   divise f (Strict.StateT l) (Strict.StateT r) = Strict.StateT $ \s ->
     divise (strictFanout f) (l s) (r s)
 
+-- | @since 5.4
 instance Divise m => Divise (Lazy.WriterT w m) where
   divise f (Lazy.WriterT l) (Lazy.WriterT r) = Lazy.WriterT $
     divise (lazyFanout f) l r
 
+-- | @since 5.4
 instance Divise m => Divise (Strict.WriterT w m) where
   divise f (Strict.WriterT l) (Strict.WriterT r) = Strict.WriterT $
     divise (strictFanout f) l r
 
 -- | Unlike 'Divisible', requires only 'Apply' on @f@.
+--
+-- @since 5.4
 instance (Apply f, Divise g) => Divise (Compose f g) where
   divise f (Compose l) (Compose r) = Compose (liftF2 (divise f) l r)
 
+-- | @since 5.4
 instance (Divise f, Divise g) => Divise (Product f g) where
   divise f (Pair l1 r1) (Pair l2 r2) = Pair (divise f l1 l2) (divise f r1 r2)
 
+-- | @since 5.4
 instance Divise f => Divise (Reverse f) where
   divise f (Reverse l) (Reverse r) = Reverse $ divise f l r
+
+-- Helpers
 
 lazyFanout :: (a -> (b, c)) -> (a, s) -> ((b, s), (c, s))
 lazyFanout f ~(a, s) = case f a of

--- a/src/Data/Functor/Contravariant/Divise.hs
+++ b/src/Data/Functor/Contravariant/Divise.hs
@@ -97,7 +97,7 @@ import GHC.Generics
 -- convolution.  That is, it is possible to define a function @(f `Day` f)
 -- a -> f a@ in a way that is associative.
 --
--- @since 5.4
+-- /Since: 5.4/
 class Contravariant f => Divise f where
     -- | Takes a \"splitting\" method and the two sub-consumers, and
     -- returns the wrapped/combined consumer.
@@ -110,183 +110,183 @@ class Contravariant f => Divise f where
 -- 'divised' = 'divise' 'id'
 -- @
 --
--- @since 5.4
+-- /Since: 5.4/
 divised :: Divise f => f a -> f b -> f (a, b)
 divised = divise id
 
 -- | Wrap a 'Divisible' to be used as a member of 'Divise'
 --
--- @since 5.4
+-- /Since: 5.4/
 newtype WrappedDivisible f a = WrapDivisible { unwrapDivisible :: f a }
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Contravariant f => Contravariant (WrappedDivisible f) where
   contramap f (WrapDivisible a) = WrapDivisible (contramap f a)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divisible f => Divise (WrappedDivisible f) where
   divise f (WrapDivisible x) (WrapDivisible y) = WrapDivisible (divide f x y)
 
 #if MIN_VERSION_base(4,9,0)
 -- | Unlike 'Divisible', requires only 'Semigroup' on @r@.
 --
--- @since 5.4
+-- /Since: 5.4/
 instance Semigroup r => Divise (Op r) where
     divise f (Op g) (Op h) = Op $ \a -> case f a of
       (b, c) -> g b <> h c
 
 -- | Unlike 'Divisible', requires only 'Semigroup' on @m@.
 --
--- @since 5.4
+-- /Since: 5.4/
 instance Semigroup m => Divise (Const m) where
     divise _ (Const a) (Const b) = Const (a <> b)
 
 -- | Unlike 'Divisible', requires only 'Semigroup' on @m@.
 --
--- @since 5.4
+-- /Since: 5.4/
 instance Semigroup m => Divise (Constant m) where
     divise _ (Constant a) (Constant b) = Constant (a <> b)
 #else
--- | @since 5.4
+-- | /Since: 5.4/
 instance Monoid r => Divise (Op r) where divise = divide
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Monoid m => Divise (Const m) where divise = divide
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Monoid m => Divise (Constant m) where divise = divide
 #endif
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise Comparison where divise = divide
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise Equivalence where divise = divide
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise Predicate where divise = divide
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise Proxy where divise = divide
 #endif
 
 #ifdef MIN_VERSION_StateVar
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise SettableStateVar where divise = divide
 #endif
 
 #if MIN_VERSION_base(4,8,0)
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise f => Divise (Alt f) where
   divise f (Alt l) (Alt r) = Alt $ divise f l r
 #endif
 
 #ifdef GHC_GENERICS
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise U1 where divise = divide
 
 -- | Has no 'Divisible' instance.
 --
--- @since 5.4
+-- /Since: 5.4/
 #if MIN_VERSION_base(4,7,0)
 instance Divise V1 where divise _ x = case x of {}
 #else
 instance Divise V1 where divise _ !_ = error "V1"
 #endif
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise f => Divise (Rec1 f) where
   divise f (Rec1 l) (Rec1 r) = Rec1 $ divise f l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise f => Divise (M1 i c f) where
   divise f (M1 l) (M1 r) = M1 $ divise f l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance (Divise f, Divise g) => Divise (f :*: g) where
   divise f (l1 :*: r1) (l2 :*: r2) = divise f l1 l2 :*: divise f r1 r2
 
 -- | Unlike 'Divisible', requires only 'Apply' on @f@.
 --
--- @since 5.4
+-- /Since: 5.4/
 instance (Apply f, Divise g) => Divise (f :.: g) where
   divise f (Comp1 l) (Comp1 r) = Comp1 (liftF2 (divise f) l r)
 #endif
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise f => Divise (Backwards f) where
   divise f (Backwards l) (Backwards r) = Backwards $ divise f l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (ErrorT e m) where
   divise f (ErrorT l) (ErrorT r) = ErrorT $ divise (funzip . fmap f) l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (ExceptT e m) where
   divise f (ExceptT l) (ExceptT r) = ExceptT $ divise (funzip . fmap f) l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise f => Divise (IdentityT f) where
   divise f (IdentityT l) (IdentityT r) = IdentityT $ divise f l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (ListT m) where
   divise f (ListT l) (ListT r) = ListT $ divise (funzip . map f) l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (MaybeT m) where
   divise f (MaybeT l) (MaybeT r) = MaybeT $ divise (funzip . fmap f) l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (ReaderT r m) where
   divise abc (ReaderT rmb) (ReaderT rmc) = ReaderT $ \r -> divise abc (rmb r) (rmc r)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (Lazy.RWST r w s m) where
   divise abc (Lazy.RWST rsmb) (Lazy.RWST rsmc) = Lazy.RWST $ \r s ->
     divise (\ ~(a, s', w) -> case abc a of
                                   ~(b, c) -> ((b, s', w), (c, s', w)))
            (rsmb r s) (rsmc r s)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (Strict.RWST r w s m) where
   divise abc (Strict.RWST rsmb) (Strict.RWST rsmc) = Strict.RWST $ \r s ->
     divise (\(a, s', w) -> case abc a of
                                 (b, c) -> ((b, s', w), (c, s', w)))
            (rsmb r s) (rsmc r s)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (Lazy.StateT s m) where
   divise f (Lazy.StateT l) (Lazy.StateT r) = Lazy.StateT $ \s ->
     divise (lazyFanout f) (l s) (r s)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (Strict.StateT s m) where
   divise f (Strict.StateT l) (Strict.StateT r) = Strict.StateT $ \s ->
     divise (strictFanout f) (l s) (r s)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (Lazy.WriterT w m) where
   divise f (Lazy.WriterT l) (Lazy.WriterT r) = Lazy.WriterT $
     divise (lazyFanout f) l r
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise m => Divise (Strict.WriterT w m) where
   divise f (Strict.WriterT l) (Strict.WriterT r) = Strict.WriterT $
     divise (strictFanout f) l r
 
 -- | Unlike 'Divisible', requires only 'Apply' on @f@.
 --
--- @since 5.4
+-- /Since: 5.4/
 instance (Apply f, Divise g) => Divise (Compose f g) where
   divise f (Compose l) (Compose r) = Compose (liftF2 (divise f) l r)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance (Divise f, Divise g) => Divise (Product f g) where
   divise f (Pair l1 r1) (Pair l2 r2) = Pair (divise f l1 l2) (divise f r1 r2)
 
--- | @since 5.4
+-- | /Since: 5.4/
 instance Divise f => Divise (Reverse f) where
   divise f (Reverse l) (Reverse r) = Reverse $ divise f l r
 

--- a/src/Data/Functor/Contravariant/Divise.hs
+++ b/src/Data/Functor/Contravariant/Divise.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE BangPatterns  #-}
 {-# LANGUAGE CPP           #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE Safe          #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 #if MIN_VERSION_base(4,7,0)
 {-# LANGUAGE EmptyCase     #-}
 #endif

--- a/src/Data/Functor/Contravariant/Divise.hs
+++ b/src/Data/Functor/Contravariant/Divise.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns  #-}
 {-# LANGUAGE CPP           #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE Safe          #-}


### PR DESCRIPTION
Supercedes #96. Additionally, repairs all issues raised by @RyanGlScott (I hope!), as well as providing three separate diagrams showing relationships among the newly-added (and existing) type classes. I've also taken the liberty of amending the changelog, adding `@since`s everywhere, and putting `Safe` pragmata in each of the new modules.