### PR TITLE
Allow building with GHC 9.2, `transformers-0.6.*`

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,5 @@
-next [????.??.??]
-----------------
+5.3.6 [????.??.??]
+------------------
 * Add `Alt` instance for `Identity`.
 * Add `Conclude`, `Decide` and `Divise` type classes and instances.
 

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,7 @@
 5.3.6 [????.??.??]
 ------------------
 * Allow building with GHC 9.2.
+* Allow building with `transformers-0.6.*`.
 * Add `Alt` instance for `Identity`.
 * Add `Conclude`, `Decide` and `Divise` type classes and instances.
 

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,6 @@
 5.3.6 [????.??.??]
 ------------------
+* Allow building with GHC 9.2.
 * Add `Alt` instance for `Identity`.
 * Add `Conclude`, `Decide` and `Divise` type classes and instances.
 

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,5 @@
-5.4 [????.??.??]
+next [????.??.??]
 ----------------
-* Remove instances for `Option`, which was removed in `base-4.16`.
 * Add `Alt` instance for `Identity`.
 * Add `Conclude`, `Decide` and `Divise` type classes and instances.
 

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -149,7 +149,7 @@ library
     base-orphans        >= 0.8.4   && < 1,
     bifunctors          >= 5.5.9   && < 6,
     template-haskell    >= 0.2.5.0,
-    transformers        >= 0.3     && < 0.6,
+    transformers        >= 0.3     && < 0.7,
     transformers-compat >= 0.5     && < 0.8
 
   if impl(ghc >= 7.0 && < 7.2)

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -1,6 +1,6 @@
 name:          semigroupoids
 category:      Control, Comonads
-version:       5.3.5
+version:       5.3.6
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -1,6 +1,6 @@
 name:          semigroupoids
 category:      Control, Comonads
-version:       5.4
+version:       5.3.5
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE

--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -188,7 +188,7 @@ instance Alt IO where
 -- | Choose the first option every time. While \'choose the last option\' every
 -- time is also valid, this instance satisfies more laws.
 --
--- @since 5.4
+-- @since 5.3.6
 instance Alt Identity where
   {-# INLINEABLE (<!>) #-}
   m <!> _ = m

--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -54,7 +54,7 @@ import Data.Functor.Product
 import Data.Functor.Reverse
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Monoid as Monoid
-import Data.Semigroup (Option(..), Semigroup(..))
+import Data.Semigroup (Semigroup(..))
 import qualified Data.Semigroup as Semigroup
 import Prelude (($),Either(..),Maybe(..),const,IO,(++),(.),either,seq,undefined,repeat)
 import Unsafe.Coerce
@@ -63,6 +63,10 @@ import Unsafe.Coerce
 import Prelude (mappend)
 #else
 import Data.Monoid (mappend)
+#endif
+
+#if !(MIN_VERSION_base(4,16,0))
+import Data.Semigroup (Option(..))
 #endif
 
 #ifdef MIN_VERSION_containers
@@ -202,8 +206,10 @@ instance Alt Maybe where
   Nothing <!> b = b
   a       <!> _ = a
 
+#if !(MIN_VERSION_base(4,16,0))
 instance Alt Option where
   (<!>) = (<|>)
+#endif
 
 instance MonadPlus m => Alt (WrappedMonad m) where
   (<!>) = (<|>)

--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -54,7 +54,7 @@ import Data.Functor.Product
 import Data.Functor.Reverse
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Monoid as Monoid
-import Data.Semigroup (Semigroup(..))
+import Data.Semigroup (Option(..), Semigroup(..))
 import qualified Data.Semigroup as Semigroup
 import Prelude (($),Either(..),Maybe(..),const,IO,(++),(.),either,seq,undefined,repeat)
 import Unsafe.Coerce
@@ -201,6 +201,9 @@ instance Alt [] where
 instance Alt Maybe where
   Nothing <!> b = b
   a       <!> _ = a
+
+instance Alt Option where
+  (<!>) = (<|>)
 
 instance MonadPlus m => Alt (WrappedMonad m) where
   (<!>) = (<|>)

--- a/src/Data/Functor/Bind/Class.hs
+++ b/src/Data/Functor/Bind/Class.hs
@@ -56,12 +56,10 @@ import Control.Arrow
 import Control.Category
 import Control.Monad (ap)
 import Control.Monad.Trans.Cont
-import Control.Monad.Trans.Error
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
-import Control.Monad.Trans.List
 import qualified Control.Monad.Trans.RWS.Lazy as Lazy
 import qualified Control.Monad.Trans.State.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
@@ -89,6 +87,11 @@ import qualified Data.Monoid as Monoid
 import Data.Orphans ()
 import Language.Haskell.TH (Q)
 import Prelude hiding (id, (.))
+
+#if !(MIN_VERSION_transformers(0,6,0))
+import Control.Monad.Trans.Error
+import Control.Monad.Trans.List
+#endif
 
 #if MIN_VERSION_base(4,6,0)
 import Data.Ord (Down (..))
@@ -346,9 +349,14 @@ instance (Hashable k, Eq k) => Apply (HashMap k) where
 instance (Functor m, Monad m) => Apply (MaybeT m) where
   (<.>) = apDefault
 
+#if !(MIN_VERSION_transformers(0,6,0))
 -- ErrorT e is _not_ the same as Compose f (Either e)
 instance (Functor m, Monad m) => Apply (ErrorT e m) where
   (<.>) = apDefault
+
+instance Apply m => Apply (ListT m) where
+  ListT f <.> ListT a = ListT $ (<.>) <$> f <.> a
+#endif
 
 instance (Functor m, Monad m) => Apply (ExceptT e m) where
   (<.>) = apDefault
@@ -356,8 +364,6 @@ instance (Functor m, Monad m) => Apply (ExceptT e m) where
 instance Apply m => Apply (ReaderT e m) where
   ReaderT f <.> ReaderT a = ReaderT $ \e -> f e <.> a e
 
-instance Apply m => Apply (ListT m) where
-  ListT f <.> ListT a = ListT $ (<.>) <$> f <.> a
 
 -- unfortunately, WriterT has its wrapped product in the wrong order to just use (<.>) instead of flap
 -- | A @'Strict.WriterT' w m@ is not 'Applicative' unless its @w@ is a 'Monoid', but it is an instance of 'Apply'
@@ -621,6 +627,7 @@ instance Monad m => Bind (WrappedMonad m) where
 instance (Functor m, Monad m) => Bind (MaybeT m) where
   (>>-) = (>>=) -- distributive law requires Monad to inject @Nothing@
 
+#if !(MIN_VERSION_transformers(0,6,0))
 instance (Apply m, Monad m) => Bind (ListT m) where
   (>>-) = (>>=) -- distributive law requires Monad to inject @[]@
 
@@ -630,6 +637,7 @@ instance (Functor m, Monad m) => Bind (ErrorT e m) where
     case a of
       Left l -> return (Left l)
       Right r -> runErrorT (k r)
+#endif
 
 instance (Functor m, Monad m) => Bind (ExceptT e m) where
   m >>- k = ExceptT $ do

--- a/src/Data/Functor/Bind/Class.hs
+++ b/src/Data/Functor/Bind/Class.hs
@@ -279,6 +279,11 @@ instance Apply Maybe where
   (<. ) = (<* )
   ( .>) = ( *>)
 
+instance Apply Option where
+  (<.>) = (<*>)
+  (<. ) = (<* )
+  ( .>) = ( *>)
+
 instance Apply Identity where
   (<.>) = (<*>)
   (<. ) = (<* )
@@ -592,6 +597,9 @@ instance Bind IO where
   (>>-) = (>>=)
 
 instance Bind Maybe where
+  (>>-) = (>>=)
+
+instance Bind Option where
   (>>-) = (>>=)
 
 instance Bind Identity where

--- a/src/Data/Functor/Bind/Class.hs
+++ b/src/Data/Functor/Bind/Class.hs
@@ -279,10 +279,12 @@ instance Apply Maybe where
   (<. ) = (<* )
   ( .>) = ( *>)
 
+#if !(MIN_VERSION_base(4,16,0))
 instance Apply Option where
   (<.>) = (<*>)
   (<. ) = (<* )
   ( .>) = ( *>)
+#endif
 
 instance Apply Identity where
   (<.>) = (<*>)
@@ -599,8 +601,10 @@ instance Bind IO where
 instance Bind Maybe where
   (>>-) = (>>=)
 
+#if !(MIN_VERSION_base(4,16,0))
 instance Bind Option where
   (>>-) = (>>=)
+#endif
 
 instance Bind Identity where
   (>>-) = (>>=)

--- a/src/Data/Functor/Contravariant/Conclude.hs
+++ b/src/Data/Functor/Contravariant/Conclude.hs
@@ -88,7 +88,7 @@ import GHC.Generics
 -- 'Decide', it adds a way to construct an \"identity\" @conclude@ where
 -- @decide f x (conclude q) == x@, and @decide g (conclude r) y == y@.
 --
--- @since 5.4
+-- @since 5.3.6
 class Decide f => Conclude f where
     -- | The consumer that cannot ever receive /any/ input.
     conclude :: (a -> Void) -> f a
@@ -101,117 +101,117 @@ class Decide f => Conclude f where
 -- 'concluded' = 'conclude' 'id'
 -- @
 --
--- @since 5.4
+-- @since 5.3.6
 concluded :: Conclude f => f Void
 concluded = conclude id
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decidable f => Conclude (WrappedDivisible f) where
     conclude f = WrapDivisible (lose f)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude Comparison where conclude = lose
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude Equivalence where conclude = lose
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude Predicate where conclude = lose
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude (Op r) where
   conclude f = Op $ absurd . f
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude Proxy where conclude = lose
 #endif
 
 #ifdef MIN_VERSION_StateVar
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude SettableStateVar where conclude = lose
 #endif
 
 #if MIN_VERSION_base(4,8,0)
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude f => Conclude (Alt f) where
   conclude = Alt . conclude
 #endif
 
 #ifdef GHC_GENERICS
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude U1 where conclude = lose
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude f => Conclude (Rec1 f) where
   conclude = Rec1 . conclude
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude f => Conclude (M1 i c f) where
   conclude = M1 . conclude
 
--- | @since 5.4
+-- | @since 5.3.6
 instance (Conclude f, Conclude g) => Conclude (f :*: g) where
   conclude f = conclude f :*: conclude f
 
--- | @since 5.4
+-- | @since 5.3.6
 instance (Apply f, Applicative f, Conclude g) => Conclude (f :.: g) where
   conclude = Comp1 . pure . conclude
 #endif
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude f => Conclude (Backwards f) where
   conclude = Backwards . conclude
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude f => Conclude (IdentityT f) where
   conclude = IdentityT . conclude
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude m => Conclude (ReaderT r m) where
   conclude f = ReaderT $ \_ -> conclude f
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude m => Conclude (Lazy.RWST r w s m) where
   conclude f = Lazy.RWST $ \_ _ -> contramap (\ ~(a, _, _) -> a) (conclude f)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude m => Conclude (Strict.RWST r w s m) where
   conclude f = Strict.RWST $ \_ _ -> contramap (\(a, _, _) -> a) (conclude f)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance (Divisible m, Divise m) => Conclude (ListT m) where
   conclude _ = ListT conquer
 
--- | @since 5.4
+-- | @since 5.3.6
 instance (Divisible m, Divise m) => Conclude (MaybeT m) where
   conclude _ = MaybeT conquer
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude m => Conclude (Lazy.StateT s m) where
   conclude f = Lazy.StateT $ \_ -> contramap lazyFst (conclude f)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude m => Conclude (Strict.StateT s m) where
   conclude f = Strict.StateT $ \_ -> contramap fst (conclude f)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude m => Conclude (Lazy.WriterT w m) where
   conclude f = Lazy.WriterT $ contramap lazyFst (conclude f)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude m => Conclude (Strict.WriterT w m) where
   conclude f = Strict.WriterT $ contramap fst (conclude f)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance (Apply f, Applicative f, Conclude g) => Conclude (Compose f g) where
   conclude = Compose . pure . conclude
 
--- | @since 5.4
+-- | @since 5.3.6
 instance (Conclude f, Conclude g) => Conclude (Product f g) where
   conclude f = Pair (conclude f) (conclude f)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Conclude f => Conclude (Reverse f) where
   conclude = Reverse . conclude
 

--- a/src/Data/Functor/Contravariant/Conclude.hs
+++ b/src/Data/Functor/Contravariant/Conclude.hs
@@ -23,7 +23,6 @@ module Data.Functor.Contravariant.Conclude (
 
 import Control.Applicative.Backwards
 import Control.Monad.Trans.Identity
-import Control.Monad.Trans.List
 import Control.Monad.Trans.Maybe
 import qualified Control.Monad.Trans.RWS.Lazy as Lazy
 import qualified Control.Monad.Trans.RWS.Strict as Strict
@@ -42,6 +41,10 @@ import Data.Functor.Contravariant.Divisible
 import Data.Functor.Product
 import Data.Functor.Reverse
 import Data.Void
+
+#if !(MIN_VERSION_transformers(0,6,0))
+import Control.Monad.Trans.List
+#endif
 
 #if MIN_VERSION_base(4,8,0)
 import Data.Monoid (Alt(..))
@@ -179,9 +182,11 @@ instance Conclude m => Conclude (Lazy.RWST r w s m) where
 instance Conclude m => Conclude (Strict.RWST r w s m) where
   conclude f = Strict.RWST $ \_ _ -> contramap (\(a, _, _) -> a) (conclude f)
 
+#if !(MIN_VERSION_transformers(0,6,0))
 -- | @since 5.3.6
 instance (Divisible m, Divise m) => Conclude (ListT m) where
   conclude _ = ListT conquer
+#endif
 
 -- | @since 5.3.6
 instance (Divisible m, Divise m) => Conclude (MaybeT m) where

--- a/src/Data/Functor/Contravariant/Decide.hs
+++ b/src/Data/Functor/Contravariant/Decide.hs
@@ -26,9 +26,7 @@ module Data.Functor.Contravariant.Decide (
   ) where
 
 import Control.Applicative.Backwards
-import Control.Arrow
 import Control.Monad.Trans.Identity
-import Control.Monad.Trans.List
 import Control.Monad.Trans.Maybe
 import qualified Control.Monad.Trans.RWS.Lazy as Lazy
 import qualified Control.Monad.Trans.RWS.Strict as Strict
@@ -38,7 +36,6 @@ import qualified Control.Monad.Trans.State.Strict as Strict
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Strict as Strict
 
-import Data.Either
 import Data.Functor.Apply
 import Data.Functor.Compose
 import Data.Functor.Contravariant
@@ -46,6 +43,12 @@ import Data.Functor.Contravariant.Divise
 import Data.Functor.Contravariant.Divisible
 import Data.Functor.Product
 import Data.Functor.Reverse
+
+#if !(MIN_VERSION_transformers(0,6,0))
+import Control.Arrow
+import Control.Monad.Trans.List
+import Data.Either
+#endif
 
 #if MIN_VERSION_base(4,8,0)
 import Data.Monoid (Alt(..))
@@ -178,9 +181,11 @@ instance Decide m => Decide (Strict.RWST r w s m) where
                                   (abc a))
            (rsmb r s) (rsmc r s)
 
+#if !(MIN_VERSION_transformers(0,6,0))
 -- | @since 5.3.6
 instance Divise m => Decide (ListT m) where
   decide f (ListT l) (ListT r) = ListT $ divise ((lefts &&& rights) . map f) l r
+#endif
 
 -- | @since 5.3.6
 instance Divise m => Decide (MaybeT m) where

--- a/src/Data/Functor/Contravariant/Decide.hs
+++ b/src/Data/Functor/Contravariant/Decide.hs
@@ -80,7 +80,7 @@ import GHC.Generics
 -- That is, it is possible to define a function @(f `EitherDay` f) a ->
 -- f a@ in a way that is associative.
 --
--- @since 5.4
+-- @since 5.3.6
 class Contravariant f => Decide f where
     -- | Takes the \"decision\" method and the two potential consumers, and
     -- returns the wrapped/combined consumer.
@@ -89,80 +89,80 @@ class Contravariant f => Decide f where
 -- | For @'decided' x y@, the resulting @f ('Either' b c)@ will direct
 -- 'Left's to be consumed by @x@, and 'Right's to be consumed by y.
 --
--- @since 5.4
+-- @since 5.3.6
 decided :: Decide f => f b -> f c -> f (Either b c)
 decided = decide id
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decidable f => Decide (WrappedDivisible f) where
     decide f (WrapDivisible x) (WrapDivisible y) = WrapDivisible (choose f x y)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide Comparison where decide = choose
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide Equivalence where decide = choose
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide Predicate where decide = choose
 
 -- | Unlike 'Decidable', requires no constraint on @r@.
 --
--- @since 5.4
+-- @since 5.3.6
 instance Decide (Op r) where
   decide f (Op g) (Op h) = Op $ either g h . f
 
 #if MIN_VERSION_base(4,8,0)
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide f => Decide (Alt f) where
   decide f (Alt l) (Alt r) = Alt $ decide f l r
 #endif
 
 #ifdef GHC_GENERICS
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide U1 where decide = choose
 
 -- | Has no 'Decidable' or 'Conclude' instance.
 --
--- @since 5.4
+-- @since 5.3.6
 #if MIN_VERSION_base(4,7,0)
 instance Decide V1 where decide _ x = case x of {}
 #else
 instance Decide V1 where decide _ x = case x of !_ -> error "V1"
 #endif
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide f => Decide (Rec1 f) where
   decide f (Rec1 l) (Rec1 r) = Rec1 $ decide f l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide f => Decide (M1 i c f) where
   decide f (M1 l) (M1 r) = M1 $ decide f l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance (Decide f, Decide g) => Decide (f :*: g) where
   decide f (l1 :*: r1) (l2 :*: r2) = decide f l1 l2 :*: decide f r1 r2
 
 -- | Unlike 'Decidable', requires only 'Apply' on @f@.
 --
--- @since 5.4
+-- @since 5.3.6
 instance (Apply f, Decide g) => Decide (f :.: g) where
   decide f (Comp1 l) (Comp1 r) = Comp1 (liftF2 (decide f) l r)
 #endif
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide f => Decide (Backwards f) where
   decide f (Backwards l) (Backwards r) = Backwards $ decide f l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide f => Decide (IdentityT f) where
   decide f (IdentityT l) (IdentityT r) = IdentityT $ decide f l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide m => Decide (ReaderT r m) where
   decide abc (ReaderT rmb) (ReaderT rmc) = ReaderT $ \r -> decide abc (rmb r) (rmc r)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide m => Decide (Lazy.RWST r w s m) where
   decide abc (Lazy.RWST rsmb) (Lazy.RWST rsmc) = Lazy.RWST $ \r s ->
     decide (\ ~(a, s', w) -> either (Left  . betuple3 s' w)
@@ -170,7 +170,7 @@ instance Decide m => Decide (Lazy.RWST r w s m) where
                                     (abc a))
            (rsmb r s) (rsmc r s)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide m => Decide (Strict.RWST r w s m) where
   decide abc (Strict.RWST rsmb) (Strict.RWST rsmc) = Strict.RWST $ \r s ->
     decide (\(a, s', w) -> either (Left  . betuple3 s' w)
@@ -178,11 +178,11 @@ instance Decide m => Decide (Strict.RWST r w s m) where
                                   (abc a))
            (rsmb r s) (rsmc r s)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Decide (ListT m) where
   decide f (ListT l) (ListT r) = ListT $ divise ((lefts &&& rights) . map f) l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Decide (MaybeT m) where
   decide f (MaybeT l) (MaybeT r) = MaybeT $
     divise ( maybe (Nothing, Nothing)
@@ -190,39 +190,39 @@ instance Divise m => Decide (MaybeT m) where
                            (\c -> (Nothing, Just c)) . f)
            ) l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide m => Decide (Lazy.StateT s m) where
   decide f (Lazy.StateT l) (Lazy.StateT r) = Lazy.StateT $ \s ->
     decide (\ ~(a, s') -> either (Left . betuple s') (Right . betuple s') (f a))
            (l s) (r s)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide m => Decide (Strict.StateT s m) where
   decide f (Strict.StateT l) (Strict.StateT r) = Strict.StateT $ \s ->
     decide (\(a, s') -> either (Left . betuple s') (Right . betuple s') (f a))
            (l s) (r s)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide m => Decide (Lazy.WriterT w m) where
   decide f (Lazy.WriterT l) (Lazy.WriterT r) = Lazy.WriterT $
     decide (\ ~(a, s') -> either (Left . betuple s') (Right . betuple s') (f a)) l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide m => Decide (Strict.WriterT w m) where
   decide f (Strict.WriterT l) (Strict.WriterT r) = Strict.WriterT $
     decide (\(a, s') -> either (Left . betuple s') (Right . betuple s') (f a)) l r
 
 -- | Unlike 'Decidable', requires only 'Apply' on @f@.
 --
--- @since 5.4
+-- @since 5.3.6
 instance (Apply f, Decide g) => Decide (Compose f g) where
   decide f (Compose l) (Compose r) = Compose (liftF2 (decide f) l r)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance (Decide f, Decide g) => Decide (Product f g) where
   decide f (Pair l1 r1) (Pair l2 r2) = Pair (decide f l1 l2) (decide f r1 r2)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide f => Decide (Reverse f) where
   decide f (Reverse l) (Reverse r) = Reverse $ decide f l r
 
@@ -233,13 +233,13 @@ betuple3 :: s -> w -> a -> (a, s, w)
 betuple3 s w a = (a, s, w)
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide Proxy where
   decide _ Proxy Proxy = Proxy
 #endif
 
 #ifdef MIN_VERSION_StateVar
--- | @since 5.4
+-- | @since 5.3.6
 instance Decide SettableStateVar where
   decide k (SettableStateVar l) (SettableStateVar r) = SettableStateVar $ \ a -> case k a of
     Left b -> l b

--- a/src/Data/Functor/Contravariant/Divise.hs
+++ b/src/Data/Functor/Contravariant/Divise.hs
@@ -85,7 +85,7 @@ import GHC.Generics
 --
 -- All instances of 'Divisible' should be instances of 'Divise' with
 -- @'divise' = 'divide'@.
--- 
+--
 -- If a function is polymorphic over @'Divise' f@ (as opposed to @'Divisible'
 -- f@), we can provide a stronger guarantee: namely, that any input consumed
 -- will be passed to at least one sub-consumer. With @'Divisible' f@, said input
@@ -97,7 +97,7 @@ import GHC.Generics
 -- convolution.  That is, it is possible to define a function @(f `Day` f)
 -- a -> f a@ in a way that is associative.
 --
--- @since 5.4
+-- @since 5.3.6
 class Contravariant f => Divise f where
     -- | Takes a \"splitting\" method and the two sub-consumers, and
     -- returns the wrapped/combined consumer.
@@ -110,183 +110,183 @@ class Contravariant f => Divise f where
 -- 'divised' = 'divise' 'id'
 -- @
 --
--- @since 5.4
+-- @since 5.3.6
 divised :: Divise f => f a -> f b -> f (a, b)
 divised = divise id
 
 -- | Wrap a 'Divisible' to be used as a member of 'Divise'
 --
--- @since 5.4
+-- @since 5.3.6
 newtype WrappedDivisible f a = WrapDivisible { unwrapDivisible :: f a }
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Contravariant f => Contravariant (WrappedDivisible f) where
   contramap f (WrapDivisible a) = WrapDivisible (contramap f a)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divisible f => Divise (WrappedDivisible f) where
   divise f (WrapDivisible x) (WrapDivisible y) = WrapDivisible (divide f x y)
 
 #if MIN_VERSION_base(4,9,0)
 -- | Unlike 'Divisible', requires only 'Semigroup' on @r@.
 --
--- @since 5.4
+-- @since 5.3.6
 instance Semigroup r => Divise (Op r) where
     divise f (Op g) (Op h) = Op $ \a -> case f a of
       (b, c) -> g b <> h c
 
 -- | Unlike 'Divisible', requires only 'Semigroup' on @m@.
 --
--- @since 5.4
+-- @since 5.3.6
 instance Semigroup m => Divise (Const m) where
     divise _ (Const a) (Const b) = Const (a <> b)
 
 -- | Unlike 'Divisible', requires only 'Semigroup' on @m@.
 --
--- @since 5.4
+-- @since 5.3.6
 instance Semigroup m => Divise (Constant m) where
     divise _ (Constant a) (Constant b) = Constant (a <> b)
 #else
--- | @since 5.4
+-- | @since 5.3.6
 instance Monoid r => Divise (Op r) where divise = divide
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Monoid m => Divise (Const m) where divise = divide
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Monoid m => Divise (Constant m) where divise = divide
 #endif
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise Comparison where divise = divide
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise Equivalence where divise = divide
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise Predicate where divise = divide
 
 #if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise Proxy where divise = divide
 #endif
 
 #ifdef MIN_VERSION_StateVar
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise SettableStateVar where divise = divide
 #endif
 
 #if MIN_VERSION_base(4,8,0)
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise f => Divise (Alt f) where
   divise f (Alt l) (Alt r) = Alt $ divise f l r
 #endif
 
 #ifdef GHC_GENERICS
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise U1 where divise = divide
 
 -- | Has no 'Divisible' instance.
 --
--- @since 5.4
+-- @since 5.3.6
 #if MIN_VERSION_base(4,7,0)
 instance Divise V1 where divise _ x = case x of {}
 #else
 instance Divise V1 where divise _ !_ = error "V1"
 #endif
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise f => Divise (Rec1 f) where
   divise f (Rec1 l) (Rec1 r) = Rec1 $ divise f l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise f => Divise (M1 i c f) where
   divise f (M1 l) (M1 r) = M1 $ divise f l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance (Divise f, Divise g) => Divise (f :*: g) where
   divise f (l1 :*: r1) (l2 :*: r2) = divise f l1 l2 :*: divise f r1 r2
 
 -- | Unlike 'Divisible', requires only 'Apply' on @f@.
 --
--- @since 5.4
+-- @since 5.3.6
 instance (Apply f, Divise g) => Divise (f :.: g) where
   divise f (Comp1 l) (Comp1 r) = Comp1 (liftF2 (divise f) l r)
 #endif
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise f => Divise (Backwards f) where
   divise f (Backwards l) (Backwards r) = Backwards $ divise f l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (ErrorT e m) where
   divise f (ErrorT l) (ErrorT r) = ErrorT $ divise (funzip . fmap f) l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (ExceptT e m) where
   divise f (ExceptT l) (ExceptT r) = ExceptT $ divise (funzip . fmap f) l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise f => Divise (IdentityT f) where
   divise f (IdentityT l) (IdentityT r) = IdentityT $ divise f l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (ListT m) where
   divise f (ListT l) (ListT r) = ListT $ divise (funzip . map f) l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (MaybeT m) where
   divise f (MaybeT l) (MaybeT r) = MaybeT $ divise (funzip . fmap f) l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (ReaderT r m) where
   divise abc (ReaderT rmb) (ReaderT rmc) = ReaderT $ \r -> divise abc (rmb r) (rmc r)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (Lazy.RWST r w s m) where
   divise abc (Lazy.RWST rsmb) (Lazy.RWST rsmc) = Lazy.RWST $ \r s ->
     divise (\ ~(a, s', w) -> case abc a of
                                   ~(b, c) -> ((b, s', w), (c, s', w)))
            (rsmb r s) (rsmc r s)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (Strict.RWST r w s m) where
   divise abc (Strict.RWST rsmb) (Strict.RWST rsmc) = Strict.RWST $ \r s ->
     divise (\(a, s', w) -> case abc a of
                                 (b, c) -> ((b, s', w), (c, s', w)))
            (rsmb r s) (rsmc r s)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (Lazy.StateT s m) where
   divise f (Lazy.StateT l) (Lazy.StateT r) = Lazy.StateT $ \s ->
     divise (lazyFanout f) (l s) (r s)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (Strict.StateT s m) where
   divise f (Strict.StateT l) (Strict.StateT r) = Strict.StateT $ \s ->
     divise (strictFanout f) (l s) (r s)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (Lazy.WriterT w m) where
   divise f (Lazy.WriterT l) (Lazy.WriterT r) = Lazy.WriterT $
     divise (lazyFanout f) l r
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise m => Divise (Strict.WriterT w m) where
   divise f (Strict.WriterT l) (Strict.WriterT r) = Strict.WriterT $
     divise (strictFanout f) l r
 
 -- | Unlike 'Divisible', requires only 'Apply' on @f@.
 --
--- @since 5.4
+-- @since 5.3.6
 instance (Apply f, Divise g) => Divise (Compose f g) where
   divise f (Compose l) (Compose r) = Compose (liftF2 (divise f) l r)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance (Divise f, Divise g) => Divise (Product f g) where
   divise f (Pair l1 r1) (Pair l2 r2) = Pair (divise f l1 l2) (divise f r1 r2)
 
--- | @since 5.4
+-- | @since 5.3.6
 instance Divise f => Divise (Reverse f) where
   divise f (Reverse l) (Reverse r) = Reverse $ divise f l r
 

--- a/src/Data/Functor/Plus.hs
+++ b/src/Data/Functor/Plus.hs
@@ -106,6 +106,9 @@ instance Plus [] where
 instance Plus Maybe where
   zero = Nothing
 
+instance Plus Option where
+  zero = empty
+
 instance MonadPlus m => Plus (WrappedMonad m) where
   zero = empty
 

--- a/src/Data/Functor/Plus.hs
+++ b/src/Data/Functor/Plus.hs
@@ -106,8 +106,10 @@ instance Plus [] where
 instance Plus Maybe where
   zero = Nothing
 
+#if !(MIN_VERSION_base(4,16,0))
 instance Plus Option where
   zero = empty
+#endif
 
 instance MonadPlus m => Plus (WrappedMonad m) where
   zero = empty

--- a/src/Data/Functor/Plus.hs
+++ b/src/Data/Functor/Plus.hs
@@ -27,9 +27,7 @@ import Control.Arrow
 import Control.Monad
 import Control.Monad.Trans.Identity
 -- import Control.Monad.Trans.Cont
-import Control.Monad.Trans.Error
 import Control.Monad.Trans.Except
-import Control.Monad.Trans.List
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
 import qualified Control.Monad.Trans.RWS.Strict as Strict
@@ -47,6 +45,11 @@ import Data.Functor.Reverse
 import qualified Data.Monoid as Monoid
 import Data.Semigroup hiding (Product)
 import Prelude hiding (id, (.))
+
+#if !(MIN_VERSION_transformers(0,6,0))
+import Control.Monad.Trans.Error
+import Control.Monad.Trans.List
+#endif
 
 #ifdef MIN_VERSION_containers
 import qualified Data.IntMap as IntMap
@@ -145,14 +148,16 @@ instance Plus f => Plus (ReaderT e f) where
 instance (Bind f, Monad f) => Plus (MaybeT f) where
   zero = MaybeT $ return zero
 
+#if !(MIN_VERSION_transformers(0,6,0))
 instance (Bind f, Monad f, Error e) => Plus (ErrorT e f) where
   zero = ErrorT $ return $ Left noMsg
 
-instance (Bind f, Monad f, Semigroup e, Monoid e) => Plus (ExceptT e f) where
-  zero = ExceptT $ return $ Left mempty
-
 instance (Apply f, Applicative f) => Plus (ListT f) where
   zero = ListT $ pure []
+#endif
+
+instance (Bind f, Monad f, Semigroup e, Monoid e) => Plus (ExceptT e f) where
+  zero = ExceptT $ return $ Left mempty
 
 instance Plus f => Plus (Strict.StateT e f) where
   zero = Strict.StateT $ \_ -> zero

--- a/src/Data/Semigroup/Foldable/Class.hs
+++ b/src/Data/Semigroup/Foldable/Class.hs
@@ -45,10 +45,6 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Complex
 #endif
 
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup (Option(..))
-#endif
-
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
 #endif
@@ -77,7 +73,7 @@ class Foldable t => Foldable1 t where
   foldMap1 :: Semigroup m => (a -> m) -> t a -> m
   toNonEmpty :: t a -> NonEmpty a
 
-  foldMap1 f = maybe (error "foldMap1") id . getOptionCompat . foldMap (optionCompat . Just . f)
+  foldMap1 f = maybe (error "foldMap1") id . getOption . foldMap (Option . Just . f)
   fold1 = foldMap1 id
   toNonEmpty = foldMap1 (:|[])
 
@@ -135,9 +131,7 @@ class Bifoldable t => Bifoldable1 t where
   {-# INLINE bifold1 #-}
 
   bifoldMap1 :: Semigroup m => (a -> m) -> (b -> m) -> t a b -> m
-  bifoldMap1 f g = maybe (error "bifoldMap1") id
-                 . getOptionCompat
-                 . bifoldMap (optionCompat . Just . f) (optionCompat . Just . g)
+  bifoldMap1 f g = maybe (error "bifoldMap1") id . getOption . bifoldMap (Option . Just . f) (Option . Just . g)
   {-# INLINE bifoldMap1 #-}
 
 instance Bifoldable1 Arg where
@@ -260,32 +254,3 @@ instance Foldable1 ((,) a) where
 instance Foldable1 g => Foldable1 (Joker g a) where
   foldMap1 g = foldMap1 g . runJoker
   {-# INLINE foldMap1 #-}
-
--- The default implementations of foldMap1 and bifoldMap1 above require the use
--- of a Maybe type with the following Monoid instance:
---
---   instance Semigroup a => Monoid (Maybe a) where ...
---
--- Unfortunately, Maybe has only had such an instance since base-4.11. Prior
--- to that, its Monoid instance had an instance context of Monoid a, which is
--- too strong. To compensate, we use CPP to define an OptionCompat type
--- synonym, which is an alias for Maybe on recent versions of base and an alias
--- for Data.Semigroup.Option on older versions of base. We don't want to use
--- Option on recent versions of base, as it has been removed.
-#if MIN_VERSION_base(4,11,0)
-type OptionCompat = Maybe
-
-optionCompat :: Maybe a -> OptionCompat a
-optionCompat = id
-
-getOptionCompat :: OptionCompat a -> Maybe a
-getOptionCompat = id
-#else
-type OptionCompat = Option
-
-optionCompat :: Maybe a -> OptionCompat a
-optionCompat = Option
-
-getOptionCompat :: OptionCompat a -> Maybe a
-getOptionCompat = getOption
-#endif


### PR DESCRIPTION
This is an alternative to the current approach in `master`. Rather than remove the instances for `Option` entirely (see f8dd1b980790d0705bdae52ea39b57f62b5ad8cd), we now guard them behind CPP. This avoids the need for a major version bump. We adopt a similar approach for the instances for `ErrorT` and `ListT`, which cannot co-exist with `transformers-0.6.*`.

Resolves #109.