### PR TITLE
Replace Bind constraints with Functor for Alt instances where possible

### DIFF
--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -50,7 +50,6 @@ import qualified Control.Monad.Trans.RWS.Lazy as Lazy
 import qualified Control.Monad.Trans.State.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import Data.Functor.Apply
-import Data.Functor.Bind
 import Data.Functor.Compose
 import Data.Functor.Identity (Identity (Identity))
 import Data.Functor.Product
@@ -253,7 +252,7 @@ instance Alt f => Alt (IdentityT f) where
 instance Alt f => Alt (ReaderT e f) where
   ReaderT a <!> ReaderT b = ReaderT $ \e -> a e <!> b e
 
-instance (Bind f, Monad f) => Alt (MaybeT f) where
+instance (Functor f, Monad f) => Alt (MaybeT f) where
   MaybeT a <!> MaybeT b = MaybeT $ do
     v <- a
     case v of
@@ -261,7 +260,7 @@ instance (Bind f, Monad f) => Alt (MaybeT f) where
       Just _ -> return v
 
 #if !(MIN_VERSION_transformers(0,6,0))
-instance (Bind f, Monad f) => Alt (ErrorT e f) where
+instance (Functor f, Monad f) => Alt (ErrorT e f) where
   ErrorT m <!> ErrorT n = ErrorT $ do
     a <- m
     case a of
@@ -272,7 +271,7 @@ instance Apply f => Alt (ListT f) where
   ListT a <!> ListT b = ListT $ (<!>) <$> a <.> b
 #endif
 
-instance (Bind f, Monad f, Semigroup e) => Alt (ExceptT e f) where
+instance (Functor f, Monad f, Semigroup e) => Alt (ExceptT e f) where
   ExceptT m <!> ExceptT n = ExceptT $ do
     a <- m
     case a of

--- a/src/Data/Functor/Plus.hs
+++ b/src/Data/Functor/Plus.hs
@@ -43,7 +43,6 @@ import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import Data.Foldable hiding (asum)
 import Data.Functor.Apply
 import Data.Functor.Alt
-import Data.Functor.Bind
 import Data.Functor.Compose
 import Data.Functor.Product
 import Data.Functor.Reverse
@@ -158,18 +157,18 @@ instance Plus f => Plus (IdentityT f) where
 instance Plus f => Plus (ReaderT e f) where
   zero = ReaderT $ \_ -> zero
 
-instance (Bind f, Monad f) => Plus (MaybeT f) where
+instance (Functor f, Monad f) => Plus (MaybeT f) where
   zero = MaybeT $ return zero
 
 #if !(MIN_VERSION_transformers(0,6,0))
-instance (Bind f, Monad f, Error e) => Plus (ErrorT e f) where
+instance (Functor f, Monad f, Error e) => Plus (ErrorT e f) where
   zero = ErrorT $ return $ Left noMsg
 
 instance (Apply f, Applicative f) => Plus (ListT f) where
   zero = ListT $ pure []
 #endif
 
-instance (Bind f, Monad f, Semigroup e, Monoid e) => Plus (ExceptT e f) where
+instance (Functor f, Monad f, Semigroup e, Monoid e) => Plus (ExceptT e f) where
   zero = ExceptT $ return $ Left mempty
 
 instance Plus f => Plus (Strict.StateT e f) where


### PR DESCRIPTION
The methods of `Bind` are not used in these instances. `Functor` is still needed for older GHC versions where it is not yet a transitive superclass of `Monad`.