### PR TITLE
Import Bifunctor from Data.Bifunctor

### DIFF
--- a/src/Data/Bifunctor/Apply.hs
+++ b/src/Data/Bifunctor/Apply.hs
@@ -25,6 +25,7 @@ module Data.Bifunctor.Apply (
   ) where
 
 import Data.Functor.Bind.Class
+import Data.Bifunctor
 import Data.Biapplicative
 
 infixl 4 <<..>>

--- a/src/Data/Functor/Bind/Class.hs
+++ b/src/Data/Functor/Bind/Class.hs
@@ -71,6 +71,7 @@ import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.RWS.Strict as Strict
 import qualified Control.Monad.Trans.State.Strict as Strict
 import qualified Control.Monad.Trans.Writer.Strict as Strict
+import Data.Bifunctor
 import Data.Biapplicative
 import Data.Bifunctor.Biff
 import Data.Bifunctor.Clown


### PR DESCRIPTION
Before bifunctors-6 the Bifunctor type class was exported from Data.Biapplicative. This commit adds support for bifunctors-6