### PR TITLE
Drop support for pre-8.0 GHCs

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.3
+# version: 0.15.20230203
 #
-# REGENDATA ("0.14.3",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.15.20230203",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,9 +28,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.2
+          - compiler: ghc-9.4.4
             compilerKind: ghc
-            compilerVersion: 9.2.2
+            compilerVersion: 9.4.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.5
+            compilerKind: ghc
+            compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -68,36 +73,6 @@ jobs:
             compilerVersion: 8.0.2
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.6.3
-            compilerKind: ghc
-            compilerVersion: 7.6.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.4.2
-            compilerKind: ghc
-            compilerVersion: 7.4.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.2.2
-            compilerKind: ghc
-            compilerVersion: 7.2.2
-            setup-method: hvr-ppa
-            allow-failure: true
-          - compiler: ghc-7.0.4
-            compilerKind: ghc
-            compilerVersion: 7.0.4
-            setup-method: hvr-ppa
-            allow-failure: true
       fail-fast: false
     steps:
       - name: apt
@@ -106,18 +81,20 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -135,13 +112,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
@@ -209,7 +186,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-docspec
           cabal-docspec --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -244,8 +221,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -267,7 +244,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
@@ -279,3 +256,9 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -comonad' --dependencies-only -j2 all
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -comonad' all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,6 @@
-5.3.8 [unreleased]
-------------------
-
+5.4 [unreleased]
+----------------
+* Drop support for GHC 7.10 and earlier.
 * Add `Generic1`-based functions for many classes, useful for writing instances:
   - `Data.Functor.Alt.(<!>)` -> `Data.Functor.Alt.galt`
   - `Data.Functor.Apply.{liftF2,liftF3}` -> `Data.Functor.Apply.{gliftF2,gliftF3}`

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,7 +1,6 @@
 distribution:           bionic
 no-tests-no-benchmarks: False
 unconstrained:          False
-allow-failures:         <7.3
 -- irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True
 docspec:                True

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -1,8 +1,8 @@
+cabal-version: 1.24
 name:          semigroupoids
 category:      Control, Comonads
-version:       5.3.7
+version:       5.4
 license:       BSD2
-cabal-version: 1.18
 license-file:  LICENSE
 author:        Edward A. Kmett
 maintainer:    Edward A. Kmett <ekmett@gmail.com>
@@ -10,20 +10,15 @@ stability:     provisional
 homepage:      http://github.com/ekmett/semigroupoids
 bug-reports:   http://github.com/ekmett/semigroupoids/issues
 copyright:     Copyright (C) 2011-2015 Edward A. Kmett
-tested-with:   GHC == 7.0.4
-             , GHC == 7.2.2
-             , GHC == 7.4.2
-             , GHC == 7.6.3
-             , GHC == 7.8.4
-             , GHC == 7.10.3
-             , GHC == 8.0.2
+tested-with:   GHC == 8.0.2
              , GHC == 8.2.2
              , GHC == 8.4.4
              , GHC == 8.6.5
              , GHC == 8.8.4
              , GHC == 8.10.7
              , GHC == 9.0.2
-             , GHC == 9.2.2
+             , GHC == 9.2.5
+             , GHC == 9.4.4
 build-type:    Simple
 synopsis:      Semigroupoids: Category sans id
 extra-source-files:
@@ -129,27 +124,15 @@ flag unordered-containers
 
 library
   build-depends:
-    base                >= 4.3     && < 5,
+    base                >= 4.9     && < 5,
     base-orphans        >= 0.8.4   && < 1,
     bifunctors          >= 5.5.9   && < 6,
-    template-haskell    >= 0.2.5.0,
-    transformers        >= 0.3     && < 0.7,
-    transformers-compat >= 0.5     && < 0.8
-
-  if impl(ghc >= 7.0 && < 7.2)
-    build-depends: generic-deriving >= 1.14 && < 1.15
-
-  if impl(ghc >= 7.2 && < 7.6)
-    build-depends: ghc-prim
-
-  if !impl(ghc >= 7.10)
-    build-depends: void >= 0.4 && < 1
-
-  if !impl(ghc >= 8.0)
-    build-depends: semigroups >= 0.18.5 && < 1
+    template-haskell    >= 0.2.11,
+    transformers        >= 0.5     && < 0.7,
+    transformers-compat >= 0.6     && < 0.8
 
   if flag(containers)
-    build-depends: containers >= 0.3 && < 0.7
+    build-depends: containers >= 0.5.7.1 && < 0.7
 
   if flag(contravariant)
     build-depends: contravariant >= 1.5.3 && < 2
@@ -164,12 +147,8 @@ library
     build-depends: tagged >= 0.8.6.1 && < 1
 
   if flag(unordered-containers)
-    if impl(ghc >= 7.4)
-      build-depends: hashable >= 1.2.7.0  && < 1.5,
-                     unordered-containers >= 0.2.8.0  && < 0.3
-    else
-      build-depends: hashable >= 1.2.5.0  && < 1.5,
-                     unordered-containers >= 0.2.8.0  && < 0.3
+    build-depends: hashable >= 1.2.7.0 && < 1.5,
+                   unordered-containers >= 0.2.8.0  && < 0.3
 
   hs-source-dirs: src
 
@@ -203,10 +182,7 @@ library
   other-modules:
     Semigroupoids.Internal
 
-  ghc-options: -Wall -fno-warn-warnings-deprecations
-
-  if impl(ghc >= 7.10)
-    ghc-options: -fno-warn-trustworthy-safe
+  ghc-options: -Wall -Wno-warnings-deprecations -Wno-trustworthy-safe
 
   if impl(ghc >= 9.0)
     -- these flags may abort compilation with GHC-8.10

--- a/src/Data/Bifunctor/Apply.hs
+++ b/src/Data/Bifunctor/Apply.hs
@@ -1,9 +1,4 @@
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett

--- a/src/Data/Functor/Alt.hs
+++ b/src/Data/Functor/Alt.hs
@@ -1,17 +1,11 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
-
-#if __GLASGOW_HASKELL__ >= 711
-{-# LANGUAGE ConstrainedClassMethods #-}
-#endif
-{-# options_ghc -fno-warn-deprecations #-}
+{-# options_ghc -Wno-deprecations #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Functor.Alt
@@ -58,20 +52,16 @@ import Data.Functor.Product
 import Data.Functor.Reverse
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Monoid as Monoid
+import Data.Proxy
 import Data.Semigroup (Semigroup(..))
 import qualified Data.Semigroup as Semigroup
-import Prelude (($),Either(..),Maybe(..),const,IO,(++),(.),either,seq,undefined,repeat)
+import GHC.Generics
+import Prelude (($),Either(..),Maybe(..),const,IO,(++),(.),either,seq,undefined,repeat,mappend)
 import Unsafe.Coerce
 
 #if !(MIN_VERSION_transformers(0,6,0))
 import Control.Monad.Trans.Error
 import Control.Monad.Trans.List
-#endif
-
-#if MIN_VERSION_base(4,8,0)
-import Prelude (mappend)
-#else
-import Data.Monoid (mappend)
 #endif
 
 #if !(MIN_VERSION_base(4,16,0))
@@ -87,23 +77,12 @@ import Data.Map (Map)
 import Prelude (Ord)
 #endif
 
-#if defined(MIN_VERSION_tagged) || (MIN_VERSION_base(4,7,0))
-import Data.Proxy
-#endif
-
 #ifdef MIN_VERSION_unordered_containers
 import Data.Hashable
 import Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as HashMap
 import Prelude (Eq)
 #endif
-
-#ifdef MIN_VERSION_generic_deriving
-import Generics.Deriving.Base
-#else
-import GHC.Generics
-#endif
-
 
 infixl 3 <!>
 
@@ -197,12 +176,10 @@ instance Alt V1 where
   some v = v `seq` undefined
   many v = v `seq` undefined
 
-#if defined(MIN_VERSION_tagged) || (MIN_VERSION_base(4,7,0))
 instance Alt Proxy where
   _ <!> _ = Proxy
   some _ = Proxy
   many _ = Proxy
-#endif
 
 instance Alt (Either a) where
   Left _ <!> b = b

--- a/src/Data/Functor/Apply.hs
+++ b/src/Data/Functor/Apply.hs
@@ -1,9 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -37,11 +33,7 @@ module Data.Functor.Apply (
 
 import Data.Functor
 import Data.Functor.Bind.Class
-#ifdef MIN_VERSION_generic_deriving
-import Generics.Deriving.Base
-#else
 import GHC.Generics
-#endif
 
 infixl 4 <..>
 
@@ -70,13 +62,3 @@ gliftF2 f wa wb = to1 $ liftF2 f (from1 wa) (from1 wb)
 -- @since 5.3.8
 gliftF3 :: (Generic1 w, Apply (Rep1 w)) => (a -> b -> c -> d) -> w a -> w b -> w c -> w d
 gliftF3 f wa wb wc = to1 $ liftF3 f (from1 wa) (from1 wb) (from1 wc)
-
-#if !(MIN_VERSION_base(4,7,0))
-
-infixl 4 $>
-
--- | Replace the contents of a functor uniformly with a constant value.
-($>) :: Functor f => f a -> b -> f b
-($>) = flip (<$)
-
-#endif

--- a/src/Data/Functor/Bind.hs
+++ b/src/Data/Functor/Bind.hs
@@ -1,13 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
-
-#if __GLASGOW_HASKELL__ >= 708 && __GLASGOW_HASKELL__ < 710
-{-# OPTIONS_GHC -fno-warn-amp #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -42,11 +34,7 @@ module Data.Functor.Bind (
 
 import Data.Functor.Apply
 import Data.Functor.Bind.Class
-#ifdef MIN_VERSION_generic_deriving
-import Generics.Deriving.Base
-#else
 import GHC.Generics
-#endif
 
 -- | Generic '(>>-)'. Caveats:
 --

--- a/src/Data/Functor/Bind/Trans.hs
+++ b/src/Data/Functor/Bind/Trans.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Functor.Bind.Trans

--- a/src/Data/Functor/Contravariant/Conclude.hs
+++ b/src/Data/Functor/Contravariant/Conclude.hs
@@ -1,11 +1,7 @@
 {-# LANGUAGE CPP           #-}
-#if __GLASGOW_HASKELL__ >= 704
-{-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE Safe #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -43,30 +39,17 @@ import Data.Functor.Contravariant.Divise
 import Data.Functor.Contravariant.Divisible
 import Data.Functor.Product
 import Data.Functor.Reverse
+import Data.Monoid (Alt(..))
+import Data.Proxy
 import Data.Void
+import GHC.Generics
 
 #if !(MIN_VERSION_transformers(0,6,0))
 import Control.Monad.Trans.List
 #endif
 
-#if MIN_VERSION_base(4,8,0)
-import Data.Monoid (Alt(..))
-#else
-import Control.Applicative
-#endif
-
-#if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
-import Data.Proxy
-#endif
-
 #ifdef MIN_VERSION_StateVar
 import Data.StateVar
-#endif
-
-#ifdef MIN_VERSION_generic_deriving
-import Generics.Deriving.Base
-#else
-import GHC.Generics
 #endif
 
 -- | The contravariant analogue of 'Plus'.  Adds on to 'Decide' the ability
@@ -144,23 +127,18 @@ instance Conclude Predicate where conclude = lose
 instance Conclude (Op r) where
   conclude f = Op $ absurd . f
 
-#if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
 -- | @since 5.3.6
 instance Conclude Proxy where conclude = lose
-#endif
 
 #ifdef MIN_VERSION_StateVar
 -- | @since 5.3.6
 instance Conclude SettableStateVar where conclude = lose
 #endif
 
-#if MIN_VERSION_base(4,8,0)
 -- | @since 5.3.6
 instance Conclude f => Conclude (Alt f) where
   conclude = Alt . conclude
-#endif
 
-#ifdef GHC_GENERICS
 -- | @since 5.3.6
 instance Conclude U1 where conclude = lose
 
@@ -179,7 +157,6 @@ instance (Conclude f, Conclude g) => Conclude (f :*: g) where
 -- | @since 5.3.6
 instance (Apply f, Applicative f, Conclude g) => Conclude (f :.: g) where
   conclude = Comp1 . pure . conclude
-#endif
 
 -- | @since 5.3.6
 instance Conclude f => Conclude (Backwards f) where

--- a/src/Data/Functor/Contravariant/Decide.hs
+++ b/src/Data/Functor/Contravariant/Decide.hs
@@ -1,15 +1,9 @@
 {-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE CPP              #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeOperators    #-}
-#if __GLASGOW_HASKELL__ >= 704
-{-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
-#if MIN_VERSION_base(4,7,0)
 {-# LANGUAGE EmptyCase #-}
-#endif
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE TypeOperators    #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -46,6 +40,9 @@ import Data.Functor.Contravariant.Divise
 import Data.Functor.Contravariant.Divisible
 import Data.Functor.Product
 import Data.Functor.Reverse
+import Data.Monoid (Alt(..))
+import Data.Proxy
+import GHC.Generics
 
 #if !(MIN_VERSION_transformers(0,6,0))
 import Control.Arrow
@@ -53,22 +50,8 @@ import Control.Monad.Trans.List
 import Data.Either
 #endif
 
-#if MIN_VERSION_base(4,8,0)
-import Data.Monoid (Alt(..))
-#endif
-
-#if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
-import Data.Proxy
-#endif
-
 #ifdef MIN_VERSION_StateVar
 import Data.StateVar
-#endif
-
-#ifdef MIN_VERSION_generic_deriving
-import Generics.Deriving.Base
-#else
-import GHC.Generics
 #endif
 
 -- | The contravariant analogue of 'Alt'.
@@ -135,24 +118,17 @@ instance Decide Predicate where decide = choose
 instance Decide (Op r) where
   decide f (Op g) (Op h) = Op $ either g h . f
 
-#if MIN_VERSION_base(4,8,0)
 -- | @since 5.3.6
 instance Decide f => Decide (Alt f) where
   decide f (Alt l) (Alt r) = Alt $ decide f l r
-#endif
 
-#ifdef GHC_GENERICS
 -- | @since 5.3.6
 instance Decide U1 where decide = choose
 
 -- | Has no 'Decidable' or 'Conclude' instance.
 --
 -- @since 5.3.6
-#if MIN_VERSION_base(4,7,0)
 instance Decide V1 where decide _ x = case x of {}
-#else
-instance Decide V1 where decide _ x = case x of !_ -> error "V1"
-#endif
 
 -- | @since 5.3.6
 instance Decide f => Decide (Rec1 f) where
@@ -171,7 +147,6 @@ instance (Decide f, Decide g) => Decide (f :*: g) where
 -- @since 5.3.6
 instance (Apply f, Decide g) => Decide (f :.: g) where
   decide f (Comp1 l) (Comp1 r) = Comp1 (liftF2 (decide f) l r)
-#endif
 
 -- | @since 5.3.6
 instance Decide f => Decide (Backwards f) where
@@ -257,11 +232,9 @@ betuple s a = (a, s)
 betuple3 :: s -> w -> a -> (a, s, w)
 betuple3 s w a = (a, s, w)
 
-#if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
 -- | @since 5.3.6
 instance Decide Proxy where
   decide _ Proxy Proxy = Proxy
-#endif
 
 #ifdef MIN_VERSION_StateVar
 -- | @since 5.3.6

--- a/src/Data/Functor/Plus.hs
+++ b/src/Data/Functor/Plus.hs
@@ -1,10 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeOperators #-}
-
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
+{-# LANGUAGE TypeOperators #-}
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -49,7 +46,9 @@ import Data.Functor.Compose
 import Data.Functor.Product
 import Data.Functor.Reverse
 import qualified Data.Monoid as Monoid
+import Data.Proxy
 import Data.Semigroup hiding (Product)
+import GHC.Generics
 import Prelude hiding (id, (.), foldr)
 
 #if !(MIN_VERSION_transformers(0,6,0))
@@ -65,20 +64,10 @@ import qualified Data.Map as Map
 import Data.Map (Map)
 #endif
 
-#if defined(MIN_VERSION_tagged) || (MIN_VERSION_base(4,7,0))
-import Data.Proxy
-#endif
-
 #ifdef MIN_VERSION_unordered_containers
 import Data.Hashable
 import Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as HashMap
-#endif
-
-#ifdef MIN_VERSION_generic_deriving
-import Generics.Deriving.Base
-#else
-import GHC.Generics
 #endif
 
 -- | Laws:

--- a/src/Data/Groupoid.hs
+++ b/src/Data/Groupoid.hs
@@ -1,12 +1,8 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -24,11 +20,8 @@ module Data.Groupoid
 
 import Data.Semigroupoid
 import Data.Semigroupoid.Dual
-
-#if MIN_VERSION_base(4,7,0)
 import qualified Data.Type.Coercion as Co
 import qualified Data.Type.Equality as Eq
-#endif
 
 -- | semigroupoid with inverses. This technically should be a category with inverses, except we need to use Ob to define the valid objects for the category
 class Semigroupoid k => Groupoid k where
@@ -37,13 +30,11 @@ class Semigroupoid k => Groupoid k where
 instance Groupoid k => Groupoid (Dual k) where
   inv (Dual k) = Dual (inv k)
 
-#if MIN_VERSION_base(4,7,0)
 instance Groupoid Co.Coercion where
   inv = Co.sym
 
 instance Groupoid (Eq.:~:) where
   inv = Eq.sym
-#endif
 
 #if MIN_VERSION_base(4,10,0)
 instance Groupoid (Eq.:~~:) where

--- a/src/Data/Isomorphism.hs
+++ b/src/Data/Isomorphism.hs
@@ -1,12 +1,5 @@
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett

--- a/src/Data/Semigroup/Bifoldable.hs
+++ b/src/Data/Semigroup/Bifoldable.hs
@@ -1,9 +1,4 @@
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett

--- a/src/Data/Semigroup/Bitraversable.hs
+++ b/src/Data/Semigroup/Bitraversable.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett

--- a/src/Data/Semigroup/Foldable.hs
+++ b/src/Data/Semigroup/Foldable.hs
@@ -1,10 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -38,13 +34,8 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Traversable.Instances ()
 import Data.Semigroup hiding (Product, Sum)
 import Data.Semigroup.Foldable.Class
-import Prelude hiding (foldr)
-
-#ifdef MIN_VERSION_generic_deriving
-import Generics.Deriving.Base
-#else
 import GHC.Generics
-#endif
+import Prelude hiding (foldr)
 
 -- $setup
 -- >>> import Data.List.NonEmpty (NonEmpty (..))

--- a/src/Data/Semigroup/Foldable/Class.hs
+++ b/src/Data/Semigroup/Foldable/Class.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE CPP, TypeOperators #-}
-
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -32,7 +29,15 @@ import Data.Bifunctor.Product as Bifunctor
 import Data.Bifunctor.Joker
 import Data.Bifunctor.Tannen
 import Data.Bifunctor.Wrapped
+import Data.Complex
 import Data.Foldable
+-- import Data.Ord -- missing Foldable, https://ghc.haskell.org/trac/ghc/ticket/15098#ticket
+import Data.Orphans ()
+import Data.Semigroup as Semigroup hiding (Product, Sum)
+import qualified Data.Monoid as Monoid
+import Data.Traversable.Instances ()
+import GHC.Generics
+import Prelude hiding (foldr)
 
 import Data.Functor.Identity
 import Data.Functor.Product as Functor
@@ -41,32 +46,13 @@ import Data.Functor.Sum as Functor
 import Data.Functor.Compose
 import Data.List.NonEmpty (NonEmpty(..))
 
-#if MIN_VERSION_base(4,4,0)
-import Data.Complex
-#endif
-
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
 #endif
 
-import Data.Traversable.Instances ()
-
 #ifdef MIN_VERSION_containers
 import Data.Tree
 #endif
-
-import qualified Data.Monoid as Monoid
-import Data.Semigroup as Semigroup hiding (Product, Sum)
-import Data.Orphans ()
--- import Data.Ord -- missing Foldable, https://ghc.haskell.org/trac/ghc/ticket/15098#ticket
-
-#ifdef MIN_VERSION_generic_deriving
-import Generics.Deriving.Base
-#else
-import GHC.Generics
-#endif
-
-import Prelude hiding (foldr)
 
 class Foldable t => Foldable1 t where
   fold1 :: Semigroup m => t m -> m
@@ -86,10 +72,8 @@ instance Foldable1 Monoid.Product where
 instance Foldable1 Monoid.Dual where
   foldMap1 f (Monoid.Dual a) = f a
 
-#if MIN_VERSION_base(4,8,0)
 instance Foldable1 f => Foldable1 (Monoid.Alt f) where
   foldMap1 g (Monoid.Alt m) = foldMap1 g m
-#endif
 
 instance Foldable1 Semigroup.First where
   foldMap1 f (Semigroup.First a) = f a
@@ -202,11 +186,9 @@ instance Bifoldable1 p => Bifoldable1 (WrappedBifunctor p) where
   bifoldMap1 f g = bifoldMap1 f g . unwrapBifunctor
   {-# INLINE bifoldMap1 #-}
 
-#if MIN_VERSION_base(4,4,0)
 instance Foldable1 Complex where
   foldMap1 f (a :+ b) = f a <> f b
   {-# INLINE foldMap1 #-}
-#endif
 
 #ifdef MIN_VERSION_containers
 instance Foldable1 Tree where

--- a/src/Data/Semigroup/Traversable.hs
+++ b/src/Data/Semigroup/Traversable.hs
@@ -1,10 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -32,11 +28,7 @@ import Data.Semigroup
 #endif
 import Data.Semigroup.Traversable.Class
 import Data.Functor.Bind.Class
-#ifdef MIN_VERSION_generic_deriving
-import Generics.Deriving.Base
-#else
 import GHC.Generics
-#endif
 
 -- | Default implementation of 'foldMap1' given an implementation of 'Traversable1'.
 foldMap1Default :: (Traversable1 f, Semigroup m) => (a -> m) -> f a -> m

--- a/src/Data/Semigroup/Traversable/Class.hs
+++ b/src/Data/Semigroup/Traversable/Class.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE CPP, TypeOperators #-}
-
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -35,6 +32,7 @@ import Data.Bifunctor.Wrapped
 import Data.Functor.Apply
 import Data.Functor.Compose
 
+import Data.Complex
 import Data.Functor.Identity
 import Data.Functor.Product as Functor
 import Data.Functor.Reverse
@@ -48,23 +46,11 @@ import Data.Semigroup.Bifoldable
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
 #endif
-#if __GLASGOW_HASKELL__ < 710
-import Data.Traversable
-#endif
 import Data.Traversable.Instances ()
-
-#if MIN_VERSION_base(4,4,0)
-import Data.Complex
-#endif
+import GHC.Generics
 
 #ifdef MIN_VERSION_containers
 import Data.Tree
-#endif
-
-#ifdef MIN_VERSION_generic_deriving
-import Generics.Deriving.Base
-#else
-import GHC.Generics
 #endif
 
 class (Bifoldable1 t, Bitraversable t) => Bitraversable1 t where
@@ -76,9 +62,7 @@ class (Bifoldable1 t, Bitraversable t) => Bitraversable1 t where
   bisequence1 = bitraverse1 id id
   {-# INLINE bisequence1 #-}
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL bitraverse1 | bisequence1 #-}
-#endif
 
 instance Bitraversable1 Arg where
   bitraverse1 f g (Arg a b) = Arg <$> f a <.> g b
@@ -156,9 +140,7 @@ class (Foldable1 t, Traversable t) => Traversable1 t where
   sequence1 = traverse1 id
   traverse1 f = sequence1 . fmap f
 
-#if __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL traverse1 | sequence1 #-}
-#endif
 
 instance Traversable1 f => Traversable1 (Rec1 f) where
   traverse1 f (Rec1 as) = Rec1 <$> traverse1 f as
@@ -208,11 +190,9 @@ instance (Traversable1 f, Traversable1 g) => Traversable1 (Functor.Sum f g) wher
   traverse1 f (Functor.InL x) = Functor.InL <$> traverse1 f x
   traverse1 f (Functor.InR y) = Functor.InR <$> traverse1 f y
 
-#if MIN_VERSION_base(4,4,0)
 instance Traversable1 Complex where
   traverse1 f (a :+ b) = (:+) <$> f a <.> f b
   {-# INLINE traverse1 #-}
-#endif
 
 #ifdef MIN_VERSION_tagged
 instance Traversable1 (Tagged a) where
@@ -244,10 +224,8 @@ instance Traversable1 Monoid.Product where
 instance Traversable1 Monoid.Dual where
   traverse1 g (Monoid.Dual a) = Monoid.Dual <$> g a
 
-#if MIN_VERSION_base(4,8,0)
 instance Traversable1 f => Traversable1 (Monoid.Alt f) where
   traverse1 g (Monoid.Alt m) = Monoid.Alt <$> traverse1 g m
-#endif
 
 instance Traversable1 Semigroup.First where
   traverse1 g (Semigroup.First a) = Semigroup.First <$> g a

--- a/src/Data/Semigroupoid.hs
+++ b/src/Data/Semigroupoid.hs
@@ -1,13 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
-
-#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
-#endif
-
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -30,9 +24,11 @@ module Data.Semigroupoid
 
 import Control.Applicative
 import Control.Arrow
+import Control.Category
 import Data.Functor.Bind
 import Data.Semigroup
-import Control.Category
+import qualified Data.Type.Coercion as Co
+import qualified Data.Type.Equality as Eq
 import Prelude hiding (id, (.))
 
 #ifdef MIN_VERSION_contravariant
@@ -46,11 +42,6 @@ import Control.Comonad
 
 #ifdef MIN_VERSION_tagged
 import Data.Tagged (Tagged (..))
-#endif
-
-#if MIN_VERSION_base(4,7,0)
-import qualified Data.Type.Coercion as Co
-import qualified Data.Type.Equality as Eq
 #endif
 
 -- | 'Control.Category.Category' sans 'Control.Category.id'
@@ -103,13 +94,11 @@ instance Semigroupoid Tagged where
   Tagged b `o` _ = Tagged b
 #endif
 
-#if MIN_VERSION_base(4,7,0)
 instance Semigroupoid Co.Coercion where
   o = flip Co.trans
 
 instance Semigroupoid (Eq.:~:) where
   o = flip Eq.trans
-#endif
 
 #if MIN_VERSION_base(4,10,0)
 instance Semigroupoid (Eq.:~~:) where

--- a/src/Data/Semigroupoid/Categorical.hs
+++ b/src/Data/Semigroupoid/Categorical.hs
@@ -1,9 +1,6 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 

--- a/src/Data/Semigroupoid/Dual.hs
+++ b/src/Data/Semigroupoid/Dual.hs
@@ -1,12 +1,5 @@
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2007-2015 Edward Kmett

--- a/src/Data/Semigroupoid/Ob.hs
+++ b/src/Data/Semigroupoid/Ob.hs
@@ -1,15 +1,9 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 706
-{-# LANGUAGE PolyKinds #-}
-#endif
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett

--- a/src/Data/Semigroupoid/Static.hs
+++ b/src/Data/Semigroupoid/Static.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE CPP #-}
-
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -31,18 +28,11 @@ import Data.Semigroup
 import Data.Semigroupoid
 import Prelude hiding ((.), id)
 
-#ifdef LANGUAGE_DeriveDataTypeable
-import Data.Typeable
-#endif
-
 #ifdef MIN_VERSION_comonad
 import Control.Comonad
 #endif
 
 newtype Static f a b = Static { runStatic :: f (a -> b) }
-#ifdef LANGUAGE_DeriveDataTypeable
-  deriving (Typeable)
-#endif
 
 instance Functor f => Functor (Static f a) where
   fmap f = Static . fmap (f .) . runStatic

--- a/src/Data/Traversable/Instances.hs
+++ b/src/Data/Traversable/Instances.hs
@@ -1,9 +1,4 @@
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015,2018 Edward Kmett

--- a/src/Semigroupoids/Do.hs
+++ b/src/Semigroupoids/Do.hs
@@ -1,18 +1,8 @@
-{-# LANGUAGE CPP #-}
-
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
-
-#if __GLASGOW_HASKELL__ == 708
-{-# OPTIONS_GHC -fno-warn-amp #-}
-#endif
 
 {-|
 
-This module re-exports operators from "Data.Functor.Apply" and 
+This module re-exports operators from "Data.Functor.Apply" and
 "Data.Functor.Bind", but under the same
 names as their 'Applicative' and 'Monad' counterparts. This makes it convenient
 to use do-notation on a type that is a 'Bind' but not a monad (or an 'Apply'
@@ -52,12 +42,7 @@ module Semigroupoids.Do
   )
 where
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (pure)
-import Prelude (String, fmap, return)
-#else
 import Prelude (String, fmap, pure, return)
-#endif
 import Data.Functor.Apply (Apply, (<.), (.>), (<.>))
 import Data.Functor.Bind (Bind, (>>-), join)
 import Data.Functor.Plus (Plus, zero)

--- a/src/Semigroupoids/Internal.hs
+++ b/src/Semigroupoids/Internal.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 module Semigroupoids.Internal where
 
@@ -11,7 +9,7 @@ import qualified Control.Monad.Trans.Writer.CPS as CPS
 import Unsafe.Coerce (unsafeCoerce)
 #endif
 
--- This is designed to avoid both https://hub.darcs.net/ross/transformers/issue/67 
+-- This is designed to avoid both https://hub.darcs.net/ross/transformers/issue/67
 -- and also the unnecessary Monoid constraints that the CPS versions of WriterT
 -- and RWST require.
 


### PR DESCRIPTION
This is a prerequisite for later changes planned in #130, where we will need to bump the lower version bounds on `bifunctors` to bring in the changes from ekmett/bifunctors#111.