### PR TITLE
Require transformers >= 0.6.1.0 with GHC-9.6

### DIFF
--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -135,6 +135,11 @@ library
   if !impl(ghc >= 9.6)
     build-depends: foldable1-classes-compat >= 0.1 && < 0.2
 
+  -- On GHC-9.6&base-4.18 we require recent enough transformers
+  -- with Foldable1 instances.
+  if impl(ghc >= 9.6)
+    build-depends: transformers >= 0.6.1.0
+
   if flag(containers)
     build-depends: containers >= 0.5.7.1 && < 0.7
 

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -135,10 +135,12 @@ library
   if !impl(ghc >= 9.6)
     build-depends: foldable1-classes-compat >= 0.1 && < 0.2
 
-  -- On GHC-9.6&base-4.18 we require recent enough transformers
+  -- On GHC-9.6&base-4.18 we require recent enough transformers and containers
   -- with Foldable1 instances.
   if impl(ghc >= 9.6)
     build-depends: transformers >= 0.6.1.0
+    if flag(containers)
+      build-depends: containers >= 0.6.7
 
   if flag(containers)
     build-depends: containers >= 0.5.7.1 && < 0.7

--- a/src/Data/Semigroup/Traversable/Class.hs
+++ b/src/Data/Semigroup/Traversable/Class.hs
@@ -11,11 +11,6 @@
 # define HAS_FOLDABLE1_CONTAINERS 0
 #endif
 
-#if MIN_VERSION_base(4,18,0)
-# define HAS_FOLDABLE1_TRANSFORMERS MIN_VERSION_transformers(0,6,1)
-#else
-# define HAS_FOLDABLE1_TRANSFORMERS 1
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -66,12 +61,10 @@ import GHC.Generics
 import Data.Tree
 #endif
 
-#if HAS_FOLDABLE1_TRANSFORMERS
 import Control.Applicative.Backwards
 import Control.Applicative.Lift
 import Control.Monad.Trans.Identity
 import Data.Functor.Reverse
-#endif
 
 class (Bifoldable1 t, Bitraversable t) => Bitraversable1 t where
   bitraverse1 :: Apply f => (a -> f b) -> (c -> f d) -> t a c -> f (t b d)
@@ -197,7 +190,6 @@ instance (Traversable1 f, Traversable1 g) => Traversable1 (Functor.Sum f g) wher
 instance (Traversable1 f, Traversable1 g) => Traversable1 (Compose f g) where
   traverse1 f = fmap Compose . traverse1 (traverse1 f) . getCompose
 
-#if HAS_FOLDABLE1_TRANSFORMERS
 instance Traversable1 f => Traversable1 (IdentityT f) where
   traverse1 f = fmap IdentityT . traverse1 f . runIdentityT
 
@@ -210,7 +202,6 @@ instance Traversable1 f => Traversable1 (Lift f) where
 
 instance Traversable1 f => Traversable1 (Reverse f) where
   traverse1 f = fmap Reverse . forwards . traverse1 (Backwards . f) . getReverse
-#endif
 
 instance Traversable1 Complex where
   traverse1 f (a :+ b) = (:+) <$> f a <.> f b

--- a/src/Data/Semigroup/Traversable/Class.hs
+++ b/src/Data/Semigroup/Traversable/Class.hs
@@ -1,16 +1,6 @@
 {-# LANGUAGE CPP, TypeOperators #-}
 {-# LANGUAGE Trustworthy #-}
 
-#ifdef MIN_VERSION_containers
-# if MIN_VERSION_base(4,18,0)
-#  define HAS_FOLDABLE1_CONTAINERS MIN_VERSION_containers(0,6,7)
-# else
-#  define HAS_FOLDABLE1_CONTAINERS 1
-# endif
-#else
-# define HAS_FOLDABLE1_CONTAINERS 0
-#endif
-
 
 -----------------------------------------------------------------------------
 -- |
@@ -57,7 +47,7 @@ import Data.Tagged
 import Data.Traversable.Instances ()
 import GHC.Generics
 
-#if HAS_FOLDABLE1_CONTAINERS
+#ifdef MIN_VERSION_containers
 import Data.Tree
 #endif
 
@@ -212,7 +202,7 @@ instance Traversable1 (Tagged a) where
   traverse1 f (Tagged a) = Tagged <$> f a
 #endif
 
-#if HAS_FOLDABLE1_CONTAINERS
+#ifdef MIN_VERSION_containers
 instance Traversable1 Tree where
   traverse1 f (Node a []) = (`Node`[]) <$> f a
   traverse1 f (Node a (x:xs)) = (\b (y:|ys) -> Node b (y:ys)) <$> f a <.> traverse1 (traverse1 f) (x :| xs)


### PR DESCRIPTION
Then we can define Traversable1 instances for Reverse, Backwards etc. unconditionally

If `semigroupoids-6` is blakclisted and `semigroupoids-6.0.0.1` released with this patch, it should indirectly fix https://github.com/ekmett/lens/issues/1028