### PR TITLE
Fix the build with `-contravariant`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230312
+# version: 0.16.6
 #
-# REGENDATA ("0.15.20230312",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.16.6",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -86,7 +86,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
@@ -95,7 +95,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
@@ -173,8 +173,8 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
@@ -182,8 +182,8 @@ jobs:
       - name: install cabal-docspec
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20211114/cabal-docspec-0.0.0.20211114.xz > cabal-docspec.xz
-          echo 'e224700d9e8c9ec7ec6bc3f542ba433cd9925a5d356676c62a9bd1f2c8be8f8a  cabal-docspec.xz' | sha256sum -c -
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20230517/cabal-docspec-0.0.0.20230517-x86_64-linux.xz > cabal-docspec.xz
+          echo '3b31bbe463ad4d671abbc103db49628562ec48a6604cab278207b5b6acd21ed7  cabal-docspec.xz' | sha256sum -c -
           xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
           rm -f cabal-docspec.xz
           chmod a+x $HOME/.cabal/bin/cabal-docspec
@@ -251,12 +251,22 @@ jobs:
       - name: prepare for constraint sets
         run: |
           rm -f cabal.project.local
+      - name: constraint set no-contravariant
+        run: |
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -contravariant' all --dry-run
+          cabal-plan topo | sort
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -contravariant' --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -contravariant' all
       - name: constraint set no-containers
         run: |
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -containers' all --dry-run
+          cabal-plan topo | sort
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -containers' --dependencies-only -j2 all
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -containers' all
       - name: constraint set no-comonad
         run: |
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -comonad' all --dry-run
+          cabal-plan topo | sort
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -comonad' --dependencies-only -j2 all
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='semigroupoids -comonad' all
       - name: save cache

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -10,3 +10,6 @@ constraint-set no-comonad
 
 constraint-set no-containers
   constraints: semigroupoids -containers
+
+constraint-set no-contravariant
+  constraints: semigroupoids -contravariant

--- a/semigroupoids.cabal
+++ b/semigroupoids.cabal
@@ -170,9 +170,6 @@ library
     Data.Functor.Bind
     Data.Functor.Bind.Class
     Data.Functor.Bind.Trans
-    Data.Functor.Contravariant.Conclude
-    Data.Functor.Contravariant.Decide
-    Data.Functor.Contravariant.Divise
     Data.Functor.Extend
     Data.Functor.Plus
     Data.Groupoid
@@ -192,6 +189,12 @@ library
     Semigroupoids.Do
   other-modules:
     Semigroupoids.Internal
+
+  if impl(ghc >= 8.6) || flag(contravariant)
+    exposed-modules:
+      Data.Functor.Contravariant.Conclude
+      Data.Functor.Contravariant.Decide
+      Data.Functor.Contravariant.Divise
 
   ghc-options: -Wall -Wno-warnings-deprecations -Wno-trustworthy-safe
 


### PR DESCRIPTION
For the most part, this is a matter of guarding the relevant definitions behind `defined(MIN_VERSION_contravariant)` CPP. I also altered some definitions to avoid relying on the `contravariant` library where they didn't need to do so.

Fixes #136.